### PR TITLE
Prove supply exchange rate monotonicity

### DIFF
--- a/Morpho/Specs/Invariants.lean
+++ b/Morpho/Specs/Invariants.lean
@@ -113,6 +113,31 @@ def lltvMonotone (s s' : MorphoState) (lltv : Uint256) : Prop :=
 def lastUpdateMonotone (s s' : MorphoState) (id : Id) : Prop :=
   (s.market id).lastUpdate.val ≤ (s'.market id).lastUpdate.val
 
+/-! ## Exchange rate monotonicity
+
+  The "exchange rate" of a supply share is the ratio of total assets to total shares
+  (with virtual offsets for inflation protection):
+  `(totalSupplyAssets + VIRTUAL_ASSETS) / (totalSupplyShares + VIRTUAL_SHARES)`.
+
+  Interest accrual must never decrease this ratio — lenders should never lose value
+  from the passage of time. When fees are zero, this is obvious (assets increase,
+  shares don't). When fees are positive, the fee recipient gets new shares computed
+  via `toSharesDown` which rounds down, ensuring existing shareholders' per-share
+  value does not decrease.
+
+  We use cross-multiplication to avoid division:
+  `oldAssets * newShares ≤ newAssets * oldShares`
+  is equivalent to `oldAssets / oldShares ≤ newAssets / newShares`.
+-/
+
+/-- Supply share value never decreases: interest accrual can only increase
+    the assets-per-share ratio (with virtual offsets). -/
+def supplyExchangeRateMonotone (s s' : MorphoState) (id : Id) : Prop :=
+  ((s.market id).totalSupplyAssets.val + SharesMathLib.VIRTUAL_ASSETS) *
+    ((s'.market id).totalSupplyShares.val + SharesMathLib.VIRTUAL_SHARES) ≤
+  ((s'.market id).totalSupplyAssets.val + SharesMathLib.VIRTUAL_ASSETS) *
+    ((s.market id).totalSupplyShares.val + SharesMathLib.VIRTUAL_SHARES)
+
 /-! ## Market isolation
 
   Morpho Blue is a singleton contract managing many independent markets.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The approach: translate Morpho's Solidity logic line-by-line into Verity's contr
 - **Fee bounds**: market fees stay within the 25% cap
 - **Collateralization**: positions with debt always have collateral, preserved by all 16 operations including borrow and withdrawCollateral (guarded by health checks; bad debt is socialized by liquidation)
 - **Monotonicity**: enabled IRMs/LLTVs cannot be disabled across all operations; market timestamps only increase through accrueInterest, setFee, and accrueInterestPublic
+- **Exchange rate safety**: supply share exchange rate never decreases after interest accrual (accrueInterest and accrueInterestPublic); existing shareholders' per-share value is protected
 - **Market isolation**: operations on one market never affect any other market's state, same-market user positions, or any position in other markets
 
 ### What this does not prove
@@ -39,7 +40,7 @@ Morpho/
     Rounding.lean         # Rounding direction specs
     Authorization.lean    # Access control specs
   Proofs/
-    Invariants.lean       # Invariant proofs (96/96 proven)
+    Invariants.lean       # Invariant proofs (98/98 proven)
     Rounding.lean         # Rounding proofs (4/4 proven)
     Authorization.lean    # Authorization proofs (11/11 proven)
 ```
@@ -54,12 +55,12 @@ lake build
 
 ## Proof progress
 
-**111 theorems proven, 0 sorry remaining.**
+**113 theorems proven, 0 sorry remaining.**
 
 | Category | Proven | Total | Status |
 |----------|--------|-------|--------|
 | Authorization | 11 | 11 | Done |
-| Invariants | 96 | 96 | Done |
+| Invariants | 98 | 98 | Done |
 | Rounding | 4 | 4 | Done |
 
 Also proven in supporting libraries:
@@ -77,6 +78,7 @@ Invariant theorems include:
 - Market isolation for all 8 operations: accrueInterest/supply/withdraw/borrow/repay/liquidate/supplyCollateral/withdrawCollateral (8)
 - Same-market position isolation for all 8 operations: accrueInterest/supply/withdraw/borrow/repay/supplyCollateral/withdrawCollateral/liquidate (8)
 - Cross-market position isolation for all 8 operations: accrueInterest/supply/withdraw/borrow/repay/supplyCollateral/withdrawCollateral/liquidate (8)
+- Exchange rate monotonicity for accrueInterest/accrueInterestPublic (2)
 - Flash loan rejects zero assets (1), accrueInterestPublic rejects uninitialized markets (1)
 - accrueInterestPublic preserves solvency and collateralization (2)
 
@@ -94,7 +96,7 @@ Authorization theorems include:
 - [x] Math libraries (MathLib, SharesMathLib, UtilsLib, ConstantsLib)
 - [x] Formal specs with human-readable documentation (invariants, rounding, authorization)
 - [x] Authorization proofs (11/11: withdraw/borrow/withdrawCollateral require auth, supply doesn't, withdraw/borrow/withdrawCollateral satisfy postcondition specs, liquidation requires unhealthy position, sig rejects expired deadline, sig rejects wrong nonce, sig increments nonce)
-- [x] Invariant proofs (96/96: IRM/LLTV monotonicity preserved by all 16 operations, LLTV < WAD, fee bounds, market creation, solvency for all 16 operations, timestamp monotonicity for accrueInterest/setFee/accrueInterestPublic, collateralization preserved by all 16 operations, market isolation for all 8 operations, same-market position isolation for all 8 operations, cross-market position isolation for all 8 operations, flashLoan rejects zero assets, accrueInterestPublic rejects uninitialized/preserves solvency/preserves collateralization)
+- [x] Invariant proofs (98/98: IRM/LLTV monotonicity preserved by all 16 operations, LLTV < WAD, fee bounds, market creation, solvency for all 16 operations, timestamp monotonicity for accrueInterest/setFee/accrueInterestPublic, exchange rate monotonicity for accrueInterest/accrueInterestPublic, collateralization preserved by all 16 operations, market isolation for all 8 operations, same-market position isolation for all 8 operations, cross-market position isolation for all 8 operations, flashLoan rejects zero assets, accrueInterestPublic rejects uninitialized/preserves solvency/preserves collateralization)
 - [x] Rounding proofs (4/4: toSharesDown ≤ toSharesUp, toAssetsDown ≤ toAssetsUp, supply round-trip protocol-safe, withdraw round-trip protocol-safe)
 
 ## License


### PR DESCRIPTION
## Summary
- Proves that the supply share exchange rate `(totalSupplyAssets + VA) / (totalSupplyShares + VS)` never decreases after `accrueInterest`, protecting existing shareholders from dilution when protocol fees mint new shares
- Adds 2 new theorems: `accrueInterest_preserves_supplyExchangeRateMonotone` and `accrueInterestPublic_preserves_supplyExchangeRateMonotone`
- Total: **113 theorems proven, 0 sorry, 0 warnings**

## Proof approach
The proof handles 4 cases:
1. **elapsed = 0**: state unchanged, trivially monotone
2. **no IRM**: only `lastUpdate` changes, trivially monotone
3. **IRM active, fee = 0**: shares unchanged, assets increase by interest — monotone by `Nat.mul_le_mul_right`
4. **IRM active, fee ≠ 0**: core case. A private helper `exchange_rate_ineq` reduces the cross-multiplication inequality to the floor division property `Nat.div_mul_le_self`, showing that `toSharesDown`-minted fee shares can never dilute the exchange rate beyond the interest added

## Hypotheses
The theorem requires standard no-overflow hypotheses:
- `h_supply_no_overflow`: `totalSupplyAssets + interest < 2^256`
- `h_shares_no_overflow`: `totalSupplyShares + feeShares < 2^256`
- `h_fee_le_interest`: `wMulDown(interest, fee) ≤ interest` (fee < WAD)
- `h_shares_vs_no_overflow`: `totalSupplyShares + VIRTUAL_SHARES < 2^256`
- `h_denom_no_overflow`: `totalSupplyAssets + interest - feeAmount + VIRTUAL_ASSETS < 2^256`

## Test plan
- [x] `lake build` passes with 0 sorry, 0 warnings
- [x] README updated with new theorem count (111 → 113, invariants 96 → 98)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof/spec-only changes; no runtime logic is modified. Main risk is introducing an incorrect spec/proof statement, but it is isolated to Lean verification artifacts.
> 
> **Overview**
> Adds a new invariant `supplyExchangeRateMonotone` (cross-multiplied assets-per-share with virtual offsets) and documents the rationale in `Specs/Invariants.lean`.
> 
> Proves this invariant is preserved by `accrueInterest` and `accrueInterestPublic` in `Proofs/Invariants.lean`, including a helper arithmetic lemma (`exchange_rate_ineq`) and explicit case splits for elapsed time, IRM disabled, zero fee, and non-zero fee (using `toSharesDown` floor-division properties under no-overflow hypotheses).
> 
> Updates `README.md` to include the new “Exchange rate safety” claim and bumps proven theorem counts (111→113, invariants 96→98).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97867d49cbd82a6b02cf80cf966c3136b77fe1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->