### PR TITLE
test: add fuzz tests, admin coverage, and security edge cases

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run Verity artifact smoke tests
         working-directory: verity-foundry
         run: forge test -vvv
+        env:
+          FOUNDRY_FUZZ_RUNS: 1000
+          FOUNDRY_FUZZ_MAX_TEST_REJECTS: 500000
 
   morpho-blue-parity:
     name: Morpho Blue differential suite (Solidity vs Verity)


### PR DESCRIPTION
## Summary
- Expand Verity smoke test suite from **26 to 38 tests** (46% increase)
- Add **4 fuzz tests** with randomized amounts for supply/withdraw, borrow/repay, collateral, and flash loans
- Add **4 admin operation tests** for `setOwner` and `setFeeRecipient` (happy path + access control)
- Add **1 multi-market isolation test** verifying operations on one market don't affect another
- Add **3 setAuthorizationWithSig security tests**: replay attack prevention, expired deadline rejection, wrong signer rejection
- Enable **1000 fuzz iterations** in CI for the Verity artifact test job (previously no fuzz config)

## New tests

| Test | Category |
|------|----------|
| `testFuzzSupplyWithdrawRoundTrip` | Fuzz: supply → withdraw full amount, verify zero residual |
| `testFuzzBorrowRepayRoundTrip` | Fuzz: borrow → repay full amount, verify zero debt |
| `testFuzzCollateralSupplyWithdraw` | Fuzz: deposit → withdraw collateral, verify round-trip |
| `testFuzzFlashLoan` | Fuzz: flash loan with random amounts |
| `testSetOwnerUpdatesOwner` | Admin: owner can transfer ownership |
| `testSetOwnerRejectsNonOwner` | Admin: non-owner cannot call setOwner |
| `testSetFeeRecipientUpdates` | Admin: owner can set fee recipient |
| `testSetFeeRecipientRejectsNonOwner` | Admin: non-owner cannot call setFeeRecipient |
| `testMultiMarketIsolation` | Isolation: supply to market A doesn't affect market B |
| `testSetAuthorizationWithSigRejectsReplay` | Security: replayed signature reverts |
| `testSetAuthorizationWithSigRejectsExpiredDeadline` | Security: expired deadline reverts |
| `testSetAuthorizationWithSigRejectsWrongSigner` | Security: wrong signer reverts |

## Test plan
- [x] All 38 tests pass locally
- [ ] CI: Lean proofs pass
- [ ] CI: Solidity tests pass
- [ ] CI: Verity smoke tests pass (with 1000 fuzz runs)
- [ ] CI: Morpho Blue parity suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and CI configuration changes; main risk is increased CI runtime/flakiness from added fuzzing rather than protocol logic changes.
> 
> **Overview**
> Expands `verity-foundry`’s `VerityMorphoSmoke.t.sol` suite with new coverage for **admin actions** (`setOwner`, `setFeeRecipient` happy paths + access control), **multi-market isolation**, and **`setAuthorizationWithSig` security edge cases** (replay, expired deadline, wrong signer).
> 
> Adds several **fuzz round-trip tests** for supply/withdraw, borrow/repay, collateral deposit/withdraw, and flash loans (requiring additional `Vm` cheatcodes), and updates the `verify.yml` GitHub Action to run the Verity artifact smoke tests with `FOUNDRY_FUZZ_RUNS=1000` (and higher reject cap).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f6d73d43a70be94f53cbb88c7261f826d0f1791. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->