### PR TITLE
Fix market id modeling and scope Solidity-bridge claims

### DIFF
--- a/Morpho/Morpho.lean
+++ b/Morpho/Morpho.lean
@@ -164,8 +164,10 @@ def setFeeRecipient (s : MorphoState) (newFeeRecipient : Address) : Option Morph
 
 /-! ## Market creation -/
 
-/-- Create a new lending market. Matches `createMarket` (Morpho.sol:150). -/
-def createMarket (s : MorphoState) (params : MarketParams) (id : Id) : Option MorphoState :=
+/-- Create a new lending market. Matches `createMarket` (Morpho.sol:150).
+    The market id is always derived from `params` (as in Solidity). -/
+def createMarket (s : MorphoState) (params : MarketParams) : Option MorphoState :=
+  let id := marketId params
   if ¬(s.isIrmEnabled params.irm) then none
   else if ¬(s.isLltvEnabled params.lltv) then none
   else let m := s.market id

--- a/Morpho/Proofs/ShareConsistency.lean
+++ b/Morpho/Proofs/ShareConsistency.lean
@@ -108,9 +108,9 @@ theorem setFeeRecipient_preserves_borrowSharesConsistent (s : MorphoState) (addr
   rw [← h_ok.right.right]; exact h_consistent
 
 theorem createMarket_preserves_supplySharesConsistent (s : MorphoState)
-    (params : MarketParams) (marketId : Id) (id : Id) (allUsers : List Address)
+    (params : MarketParams) (id : Id) (allUsers : List Address)
     (h_consistent : supplySharesConsistent s id allUsers)
-    (h_ok : Morpho.createMarket s params marketId = some s') :
+    (h_ok : Morpho.createMarket s params = some s') :
     supplySharesConsistent s' id allUsers := by
   unfold Morpho.createMarket at h_ok; simp at h_ok
   obtain ⟨_, _, _, h_eq⟩ := h_ok
@@ -120,9 +120,9 @@ theorem createMarket_preserves_supplySharesConsistent (s : MorphoState)
   · intro u; rfl
 
 theorem createMarket_preserves_borrowSharesConsistent (s : MorphoState)
-    (params : MarketParams) (marketId : Id) (id : Id) (allUsers : List Address)
+    (params : MarketParams) (id : Id) (allUsers : List Address)
     (h_consistent : borrowSharesConsistent s id allUsers)
-    (h_ok : Morpho.createMarket s params marketId = some s') :
+    (h_ok : Morpho.createMarket s params = some s') :
     borrowSharesConsistent s' id allUsers := by
   unfold Morpho.createMarket at h_ok; simp at h_ok
   obtain ⟨_, _, _, h_eq⟩ := h_ok

--- a/Morpho/Proofs/SolidityBridge.lean
+++ b/Morpho/Proofs/SolidityBridge.lean
@@ -61,7 +61,7 @@ abbrev SetFeeRecipientSem :=
   MorphoState → Address → Option MorphoState
 
 abbrev CreateMarketSem :=
-  MorphoState → MarketParams → Id → Option MorphoState
+  MorphoState → MarketParams → Option MorphoState
 
 abbrev SetFeeSem :=
   MorphoState → Id → Uint256 → Uint256 → Bool → Option MorphoState
@@ -134,8 +134,8 @@ def setFeeRecipientSemEq (soliditySetFeeRecipient : SetFeeRecipientSem) : Prop :
     soliditySetFeeRecipient s newFeeRecipient = Morpho.setFeeRecipient s newFeeRecipient
 
 def createMarketSemEq (solidityCreateMarket : CreateMarketSem) : Prop :=
-  ∀ s params marketId,
-    solidityCreateMarket s params marketId = Morpho.createMarket s params marketId
+  ∀ s params,
+    solidityCreateMarket s params = Morpho.createMarket s params
 
 def setFeeSemEq (soliditySetFee : SetFeeSem) : Prop :=
   ∀ s id newFee borrowRate hasIrm,
@@ -862,46 +862,46 @@ theorem solidity_setFeeRecipient_preserves_lltvMonotone
 theorem solidity_createMarket_preserves_borrowLeSupply
     (solidityCreateMarket : CreateMarketSem)
     (h_eq : createMarketSemEq solidityCreateMarket)
-    (s : MorphoState) (params : MarketParams) (marketId id : Id) (s' : MorphoState)
+    (s : MorphoState) (params : MarketParams) (id : Id) (s' : MorphoState)
     (h_solvent : borrowLeSupply s id)
-    (h_ok : solidityCreateMarket s params marketId = some s') :
+    (h_ok : solidityCreateMarket s params = some s') :
     borrowLeSupply s' id := by
-  have h_ok_morpho : Morpho.createMarket s params marketId = some s' := by
-    simpa [createMarketSemEq] using (h_eq s params marketId).symm.trans h_ok
-  exact createMarket_preserves_borrowLeSupply s params marketId id h_solvent h_ok_morpho
+  have h_ok_morpho : Morpho.createMarket s params = some s' := by
+    simpa [createMarketSemEq] using (h_eq s params).symm.trans h_ok
+  exact createMarket_preserves_borrowLeSupply s params id h_solvent h_ok_morpho
 
 theorem solidity_createMarket_preserves_alwaysCollateralized
     (solidityCreateMarket : CreateMarketSem)
     (h_eq : createMarketSemEq solidityCreateMarket)
-    (s : MorphoState) (params : MarketParams) (marketId id : Id) (user : Address) (s' : MorphoState)
+    (s : MorphoState) (params : MarketParams) (id : Id) (user : Address) (s' : MorphoState)
     (h_collat : alwaysCollateralized s id user)
-    (h_ok : solidityCreateMarket s params marketId = some s') :
+    (h_ok : solidityCreateMarket s params = some s') :
     alwaysCollateralized s' id user := by
-  have h_ok_morpho : Morpho.createMarket s params marketId = some s' := by
-    simpa [createMarketSemEq] using (h_eq s params marketId).symm.trans h_ok
-  exact createMarket_preserves_alwaysCollateralized s params marketId id user h_collat h_ok_morpho
+  have h_ok_morpho : Morpho.createMarket s params = some s' := by
+    simpa [createMarketSemEq] using (h_eq s params).symm.trans h_ok
+  exact createMarket_preserves_alwaysCollateralized s params id user h_collat h_ok_morpho
 
 theorem solidity_createMarket_preserves_irmMonotone
     (solidityCreateMarket : CreateMarketSem)
     (h_eq : createMarketSemEq solidityCreateMarket)
-    (s : MorphoState) (params : MarketParams) (marketId : Id) (irm : Address) (s' : MorphoState)
+    (s : MorphoState) (params : MarketParams) (irm : Address) (s' : MorphoState)
     (h_enabled : s.isIrmEnabled irm)
-    (h_ok : solidityCreateMarket s params marketId = some s') :
+    (h_ok : solidityCreateMarket s params = some s') :
     s'.isIrmEnabled irm := by
-  have h_ok_morpho : Morpho.createMarket s params marketId = some s' := by
-    simpa [createMarketSemEq] using (h_eq s params marketId).symm.trans h_ok
-  exact createMarket_preserves_irmMonotone s params marketId irm h_enabled h_ok_morpho
+  have h_ok_morpho : Morpho.createMarket s params = some s' := by
+    simpa [createMarketSemEq] using (h_eq s params).symm.trans h_ok
+  exact createMarket_preserves_irmMonotone s params irm h_enabled h_ok_morpho
 
 theorem solidity_createMarket_preserves_lltvMonotone
     (solidityCreateMarket : CreateMarketSem)
     (h_eq : createMarketSemEq solidityCreateMarket)
-    (s : MorphoState) (params : MarketParams) (marketId : Id) (lltv : Uint256) (s' : MorphoState)
+    (s : MorphoState) (params : MarketParams) (lltv : Uint256) (s' : MorphoState)
     (h_enabled : s.isLltvEnabled lltv)
-    (h_ok : solidityCreateMarket s params marketId = some s') :
+    (h_ok : solidityCreateMarket s params = some s') :
     s'.isLltvEnabled lltv := by
-  have h_ok_morpho : Morpho.createMarket s params marketId = some s' := by
-    simpa [createMarketSemEq] using (h_eq s params marketId).symm.trans h_ok
-  exact createMarket_preserves_lltvMonotone s params marketId lltv h_enabled h_ok_morpho
+  have h_ok_morpho : Morpho.createMarket s params = some s' := by
+    simpa [createMarketSemEq] using (h_eq s params).symm.trans h_ok
+  exact createMarket_preserves_lltvMonotone s params lltv h_enabled h_ok_morpho
 
 theorem solidity_setFee_preserves_borrowLeSupply
     (soliditySetFee : SetFeeSem)

--- a/README.md
+++ b/README.md
@@ -44,12 +44,22 @@ Machine-readable parity target artifacts:
 - [`scripts/check_parity_target.py`](scripts/check_parity_target.py)
 - [`scripts/report_yul_identity_gap.py`](scripts/report_yul_identity_gap.py)
 
+Some theorems are conditional on arithmetic side conditions (`h_no_overflow`) that model Solidity checked arithmetic.
+These are explicit theorem hypotheses today, not globally discharged reachability facts.
+
 ### Solidity Equivalence Bridge
 
 `Morpho/Proofs/SolidityBridge.lean` adds 46 proof-transfer theorems for core invariants.
+This file is a conditional transfer layer: it assumes operation-by-operation semantic equivalence hypotheses and then transports proved invariants.
 If a Solidity/Yul semantics model is shown equivalent to each corresponding Verity operation
 (`supply`, `withdraw`, `borrow`, `repay`, `supplyCollateral`, `withdrawCollateral`, `liquidate`, `accrueInterest`, `enableIrm`, `enableLltv`, `setAuthorization`, `setAuthorizationWithSig`),
 the existing Verity proofs for `borrowLeSupply`, `alwaysCollateralized`, `irmMonotone`, and `lltvMonotone` transfer directly to Solidity.
+
+## Key Modeling Notes
+
+- `createMarket` now derives `id = marketId(params)` inside the transition (matching Solidity), so callers cannot provide arbitrary ids.
+- `marketId` is no longer a constant placeholder; it is a deterministic function of `MarketParams`.
+- Interest accrual remains a compositional model (`accrueInterest` can be called explicitly by clients/proofs), while Solidity calls it internally in several entrypoints.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
This PR addresses the highest-impact issues from the review around market identity modeling and claim scope.

### 1) `createMarket` id derivation is now Solidity-aligned
- `Morpho.createMarket` no longer accepts an arbitrary `id` argument.
- It now computes `id := marketId params` internally, matching Solidity behavior (`id = keccak256(marketParams)` in spirit).
- This removes the ability to create a market under caller-chosen ids in the Lean model.

### 2) `marketId` is no longer a constant placeholder
- Replaced the constant `0` stub with a deterministic function of `MarketParams`.
- This restores meaningful market partitioning in the model and avoids the previous degenerate behavior.

### 3) Bridge + model-scope documentation tightened
- README now explicitly states:
  - `SolidityBridge` is a **conditional transfer layer** (requires semantic equivalence hypotheses).
  - overflow-related theorem hypotheses are explicit assumptions, not globally discharged reachability facts.
  - createMarket/id modeling details and the compositional accrual model are called out directly.

### 4) Proof/bridge updates for signature changes
- Updated invariant and share-consistency theorems to the new `createMarket` signature.
- Updated `SolidityBridge` `CreateMarketSem` and all dependent transfer theorems accordingly.

## Validation
- `lake build` passes.
- Full parity suite passes after changes:
  - Solidity: 145/145
  - Verity: 145/145
  - Logs: `out/parity/morpho_blue_solidity.log`, `out/parity/morpho_blue_verity.log`

## Notes
This PR intentionally does **not** claim to complete end-to-end Solidity semantic equivalence or discharge all environmental assumptions (oracle/IRM/token/signature internals). It makes those boundaries explicit and removes a concrete model unsoundness around market ids.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core market identity modeling (`marketId` and `createMarket`) and ripples through invariant/bridge theorem signatures; mistakes could invalidate proof assumptions or break downstream callers even though runtime state updates remain minimal.
> 
> **Overview**
> Aligns market identity with Solidity by making `createMarket` derive `id := marketId params` internally (removing the caller-supplied `id`) and by replacing the `marketId` constant stub with a deterministic hash-like function over `MarketParams`.
> 
> Updates all dependent proofs and the Solidity equivalence bridge to the new `createMarket` signature, and refreshes README language to clarify that bridge theorems and overflow-related side conditions are *conditional assumptions* rather than globally proven facts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74a1f9dbd21d3a1b8e5cc538a28cc506978e5d3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->