### PR TITLE
Add fail-closed toolchain readiness gates across CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,6 +39,8 @@ jobs:
         run: ./scripts/run_with_timeout.sh MORPHO_LEAN_INSTALL_TIMEOUT_SEC 600 "Install Lean toolchain" -- ./scripts/install_lean.sh
       - name: Add elan bin to PATH
         run: echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Check Lean toolchain readiness
+        run: ./scripts/check_toolchain_readiness.sh --require lean
 
       - name: Build and check proofs
         run: ./scripts/run_with_timeout.sh MORPHO_VERITY_PROOFS_TIMEOUT_SEC 1500 "Build and check Lean proofs" -- lake build
@@ -72,6 +74,8 @@ jobs:
 
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
+      - name: Check solc toolchain readiness
+        run: ./scripts/check_toolchain_readiness.sh --require solc
 
       - name: Validate pinned parity target
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate pinned parity target" -- python3 scripts/check_parity_target.py
@@ -93,6 +97,8 @@ jobs:
 
       - name: Run Foundry installer unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Foundry installer unit tests" -- ./scripts/test_install_foundry.sh
+      - name: Run toolchain readiness unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Toolchain readiness unit tests" -- ./scripts/test_check_toolchain_readiness.sh
 
       - name: Run Lean installer unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Lean installer unit tests" -- ./scripts/test_install_lean.sh
@@ -161,6 +167,8 @@ jobs:
 
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
+      - name: Check full toolchain readiness
+        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Generate Yul identity report
         run: ./scripts/run_with_timeout.sh MORPHO_YUL_IDENTITY_TIMEOUT_SEC 1500 "Yul identity report" -- python3 scripts/report_yul_identity_gap.py --max-diff-lines 12000 --enforce-unsupported-manifest
@@ -203,6 +211,8 @@ jobs:
 
       - name: Install Foundry
         run: ./scripts/run_with_timeout.sh MORPHO_FOUNDRY_INSTALL_TIMEOUT_SEC 600 "Install Foundry" -- ./scripts/install_foundry.sh
+      - name: Check Foundry readiness
+        run: ./scripts/check_toolchain_readiness.sh --require foundry
 
       - name: Run Morpho Blue tests
         working-directory: morpho-blue
@@ -269,6 +279,8 @@ jobs:
 
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
+      - name: Check full toolchain readiness
+        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Compile Morpho Verity artifact and enforce model/edsl parity
         run: ./scripts/run_with_timeout.sh MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC 2400 "Input-mode parity gate" -- ./scripts/check_input_mode_parity.sh
@@ -340,6 +352,8 @@ jobs:
 
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
+      - name: Check full toolchain readiness
+        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Run full Morpho Blue parity script
         run: ./scripts/run_with_timeout.sh MORPHO_BLUE_PARITY_SCRIPT_TIMEOUT_SEC 6900 "Morpho Blue differential parity script" -- ./scripts/run_morpho_blue_parity.sh

--- a/scripts/check_toolchain_readiness.sh
+++ b/scripts/check_toolchain_readiness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: check_toolchain_readiness.sh [--require <lean|foundry|solc>]...
+
+Checks that required toolchain binaries are available and executable.
+When no --require flags are provided, defaults to: lean, foundry, solc.
+USAGE
+}
+
+requirement_enabled() {
+  local name="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "${item}" == "${name}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_binary() {
+  local label="$1"
+  local bin="$2"
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    echo "ERROR: missing required ${label} binary: ${bin}" >&2
+    return 1
+  fi
+  return 0
+}
+
+show_version() {
+  local bin="$1"
+  local fallback="$2"
+  if ! "${bin}" --version 2>/dev/null; then
+    if [[ -n "${fallback}" ]]; then
+      "${bin}" "${fallback}" 2>/dev/null || true
+    fi
+  fi
+}
+
+requirements=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --require)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: missing value for --require" >&2
+        usage >&2
+        exit 2
+      fi
+      case "$2" in
+        lean|foundry|solc)
+          requirements+=("$2")
+          ;;
+        *)
+          echo "ERROR: invalid --require value '$2' (expected lean, foundry, or solc)" >&2
+          usage >&2
+          exit 2
+          ;;
+      esac
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${#requirements[@]} -eq 0 ]]; then
+  requirements=(lean foundry solc)
+fi
+
+status=0
+
+if requirement_enabled lean "${requirements[@]}"; then
+  check_binary "Lean toolchain" lean || status=1
+  check_binary "Lean toolchain" lake || status=1
+fi
+
+if requirement_enabled foundry "${requirements[@]}"; then
+  check_binary "Foundry" forge || status=1
+  check_binary "Foundry" anvil || status=1
+fi
+
+if requirement_enabled solc "${requirements[@]}"; then
+  check_binary "solc toolchain" solc || status=1
+  check_binary "solc toolchain" solc-select || status=1
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+  echo "ERROR: toolchain readiness check failed." >&2
+  echo "DEBUG: PATH=${PATH}" >&2
+  exit 127
+fi
+
+echo "Toolchain readiness check passed for requirements: ${requirements[*]}"
+if requirement_enabled lean "${requirements[@]}"; then
+  show_version lean ""
+fi
+if requirement_enabled foundry "${requirements[@]}"; then
+  show_version forge ""
+  show_version anvil ""
+fi
+if requirement_enabled solc "${requirements[@]}"; then
+  show_version solc ""
+  show_version solc-select "versions"
+fi

--- a/scripts/test_check_toolchain_readiness.sh
+++ b/scripts/test_check_toolchain_readiness.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${ROOT_DIR}/scripts/check_toolchain_readiness.sh"
+
+assert_contains() {
+  local needle="$1"
+  local haystack_file="$2"
+  if ! grep -Fq "${needle}" "${haystack_file}"; then
+    echo "ASSERTION FAILED: expected to find '${needle}' in ${haystack_file}"
+    exit 1
+  fi
+}
+
+make_exe() {
+  local path="$1"
+  local content="$2"
+  cat > "${path}" <<EOF_INNER
+${content}
+EOF_INNER
+  chmod +x "${path}"
+}
+
+test_passes_when_all_default_requirements_exist() {
+  local fake_root fake_bin output_file
+  fake_root="$(mktemp -d)"
+  fake_bin="${fake_root}/bin"
+  output_file="$(mktemp)"
+  trap 'rm -rf "${fake_root}" "${output_file}"' RETURN
+
+  mkdir -p "${fake_bin}"
+  make_exe "${fake_bin}/lean" '#!/usr/bin/env bash
+set -euo pipefail
+echo "Lean (version 4.22.0)"'
+  make_exe "${fake_bin}/lake" '#!/usr/bin/env bash
+set -euo pipefail
+echo "Lake version 5.0.0"'
+  make_exe "${fake_bin}/forge" '#!/usr/bin/env bash
+set -euo pipefail
+echo "forge 1.4.0"'
+  make_exe "${fake_bin}/anvil" '#!/usr/bin/env bash
+set -euo pipefail
+echo "anvil 1.4.0"'
+  make_exe "${fake_bin}/solc" '#!/usr/bin/env bash
+set -euo pipefail
+echo "Version: 0.8.28"'
+  make_exe "${fake_bin}/solc-select" '#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "versions" ]]; then
+  echo "0.8.28"
+else
+  echo "solc-select"
+fi'
+
+  PATH="${fake_bin}:/usr/bin:/bin" \
+    "${SCRIPT_UNDER_TEST}" >"${output_file}" 2>&1
+
+  assert_contains "Toolchain readiness check passed for requirements: lean foundry solc" "${output_file}"
+  assert_contains "forge 1.4.0" "${output_file}"
+}
+
+test_fail_closed_when_required_binary_missing() {
+  local fake_root fake_bin output_file rc
+  fake_root="$(mktemp -d)"
+  fake_bin="${fake_root}/bin"
+  output_file="$(mktemp)"
+  trap 'rm -rf "${fake_root}" "${output_file}"' RETURN
+
+  mkdir -p "${fake_bin}"
+  make_exe "${fake_bin}/forge" '#!/usr/bin/env bash
+set -euo pipefail
+echo "forge 1.4.0"'
+
+  rc=0
+  if PATH="${fake_bin}:/usr/bin:/bin" "${SCRIPT_UNDER_TEST}" --require foundry >"${output_file}" 2>&1; then
+    echo "ASSERTION FAILED: expected readiness check to fail when anvil is missing"
+    exit 1
+  else
+    rc=$?
+  fi
+
+  if [[ "${rc}" -ne 127 ]]; then
+    echo "ASSERTION FAILED: expected exit code 127, got ${rc}"
+    exit 1
+  fi
+
+  assert_contains "ERROR: missing required Foundry binary: anvil" "${output_file}"
+  assert_contains "ERROR: toolchain readiness check failed." "${output_file}"
+}
+
+test_can_target_single_requirement() {
+  local fake_root fake_bin output_file
+  fake_root="$(mktemp -d)"
+  fake_bin="${fake_root}/bin"
+  output_file="$(mktemp)"
+  trap 'rm -rf "${fake_root}" "${output_file}"' RETURN
+
+  mkdir -p "${fake_bin}"
+  make_exe "${fake_bin}/lean" '#!/usr/bin/env bash
+set -euo pipefail
+echo "Lean (version 4.22.0)"'
+  make_exe "${fake_bin}/lake" '#!/usr/bin/env bash
+set -euo pipefail
+echo "Lake version 5.0.0"'
+
+  PATH="${fake_bin}:/usr/bin:/bin" \
+    "${SCRIPT_UNDER_TEST}" --require lean >"${output_file}" 2>&1
+
+  assert_contains "Toolchain readiness check passed for requirements: lean" "${output_file}"
+}
+
+test_rejects_invalid_requirement_name() {
+  local output_file rc
+  output_file="$(mktemp)"
+  trap 'rm -f "${output_file}"' RETURN
+
+  rc=0
+  if "${SCRIPT_UNDER_TEST}" --require foo >"${output_file}" 2>&1; then
+    echo "ASSERTION FAILED: expected invalid requirement to fail"
+    exit 1
+  else
+    rc=$?
+  fi
+
+  if [[ "${rc}" -ne 2 ]]; then
+    echo "ASSERTION FAILED: expected exit code 2, got ${rc}"
+    exit 1
+  fi
+
+  assert_contains "ERROR: invalid --require value 'foo'" "${output_file}"
+}
+
+test_passes_when_all_default_requirements_exist
+test_fail_closed_when_required_binary_missing
+test_can_target_single_requirement
+test_rejects_invalid_requirement_name
+
+echo "check_toolchain_readiness.sh tests passed"


### PR DESCRIPTION
## Summary
- add `scripts/check_toolchain_readiness.sh` to fail-closed on missing Lean/Foundry/solc binaries
- add `scripts/test_check_toolchain_readiness.sh` coverage for success/failure/invalid-input cases
- wire readiness checks into `verify.yml` jobs after installation steps to fail fast at trust boundaries

## Why
Recent migration work stabilized Foundry installation, but long CI lanes could still fail late if one toolchain binary was missing on a specific runner/cache shape. This change adds explicit post-install readiness assertions so failures are deterministic and early.

## Validation
- `./scripts/test_check_toolchain_readiness.sh`
- `./scripts/test_install_foundry.sh`
- `./scripts/test_install_lean.sh`
- `./scripts/test_install_solc.sh`
- `lake build Morpho.Compiler.Main Morpho.Compiler.MainTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new CI-only validation steps and small bash scripts that fail early if required binaries are missing, without affecting production code paths.
> 
> **Overview**
> Adds a new `scripts/check_toolchain_readiness.sh` script that **fails closed** if required toolchain binaries (Lean/Lake, Foundry `forge`/`anvil`, solc/`solc-select`) are missing, and prints versions on success.
> 
> Updates `.github/workflows/verify.yml` to run readiness checks immediately after tool installs (Lean-only, solc-only, Foundry-only, and full toolchain) and adds a CI unit test script `scripts/test_check_toolchain_readiness.sh` to cover success, missing-binary failure (exit `127`), and invalid-flag handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6519f8277e65d16e4701a2742cdb7ba13c97e65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->