### PR TITLE
Canonicalize Morpho input mode to generalized edsl path

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Build the Morpho Verity artifact:
 
 Artifact preparation is fail-closed for invalid toggle values and missing required tooling:
 - `MORPHO_VERITY_SKIP_BUILD` / `MORPHO_VERITY_SKIP_SOLC` must be `0` or `1`.
-- `MORPHO_VERITY_INPUT_MODE` must be `model` or `edsl`.
+- `MORPHO_VERITY_INPUT_MODE` must be `model` or `edsl` (`model` is a compatibility alias of the canonical `edsl` path).
 - `python3` is required to read `config/parity-target.json` when present.
 - `config/parity-target.json` must include a non-empty `verity.parityPackId`.
 - `compiler/external-libs/MarketParamsHash.yul` must be present.
@@ -184,7 +184,7 @@ Generate only Yul + ABI (skip `solc` bytecode generation):
 MORPHO_VERITY_SKIP_SOLC=1 ./scripts/prepare_verity_morpho_artifact.sh
 ```
 
-Select compiler input boundary mode explicitly (`edsl` default, routed through Verity's generalized lowering boundary):
+Select compiler input boundary mode explicitly (`edsl` default, routed through Verity's generalized lowering boundary; `model` remains accepted as a compatibility alias):
 
 ```bash
 MORPHO_VERITY_INPUT_MODE=model ./scripts/prepare_verity_morpho_artifact.sh


### PR DESCRIPTION
## Summary
- remove redundant internal compiler branch between `--input model` and `--input edsl`
- keep `--input model` accepted as a compatibility alias
- document alias behavior in CLI help and README

## Why
Morpho migration now targets Verity's generalized lowering boundary. Keeping two internal modes adds surface area without semantic differences. This change preserves backward compatibility while making the compiler path single-source internally.

## Changes
- `Morpho/Compiler/Main.lean`
  - simplify `lowerMorphoSpec` to always lower through `lowerModelPath`
  - keep parser accepting `model|edsl`
  - print explicit verbose message when `model` alias is used
  - update `--help` text to clarify alias semantics
- `README.md`
  - clarify `MORPHO_VERITY_INPUT_MODE=model` is compatibility alias

## Validation
- `lake build Morpho.Compiler.Main Morpho.Compiler.MainTest`
- `./scripts/test_prepare_verity_morpho_artifact.sh`
- `./scripts/test_check_input_mode_parity.sh`
- `./scripts/test_check_toolchain_readiness.sh`
- `./scripts/test_install_foundry.sh`
- `./scripts/test_install_lean.sh`
- `./scripts/test_install_solc.sh`

Closes part of #31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant `model` vs `edsl` lowering branch while keeping `model` accepted as an alias; behavior should be unchanged aside from clearer messaging.
> 
> **Overview**
> Canonicalizes the compiler’s input-boundary handling by removing the internal `model` vs `edsl` branching and always lowering Morpho specs through the same `edsl`-based path.
> 
> Keeps `--input model`/`MORPHO_VERITY_INPUT_MODE=model` accepted as a compatibility alias, and updates verbose logging plus `--help`/README text to explicitly document the alias and canonicalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be6f70f09917f51055e23e0fe5cd161ab436baa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->