### PR TITLE
Canonicalize script input alias to edsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Build the Morpho Verity artifact:
 
 Artifact preparation is fail-closed for invalid toggle values and missing required tooling:
 - `MORPHO_VERITY_SKIP_BUILD` / `MORPHO_VERITY_SKIP_SOLC` must be `0` or `1`.
-- `MORPHO_VERITY_INPUT_MODE` must be `model` or `edsl` (`model` is a compatibility alias of the canonical `edsl` path).
+- `MORPHO_VERITY_INPUT_MODE` must be `model` or `edsl` (`model` is a compatibility alias and is canonicalized to `edsl` before compiler invocation).
 - `python3` is required to read `config/parity-target.json` when present.
 - `config/parity-target.json` must include a non-empty `verity.parityPackId`.
 - `compiler/external-libs/MarketParamsHash.yul` must be present.

--- a/scripts/prepare_verity_morpho_artifact.sh
+++ b/scripts/prepare_verity_morpho_artifact.sh
@@ -30,6 +30,7 @@ validate_toggle() {
 INPUT_MODE="${MORPHO_VERITY_INPUT_MODE:-edsl}"
 SKIP_BUILD="${MORPHO_VERITY_SKIP_BUILD:-0}"
 SKIP_SOLC="${MORPHO_VERITY_SKIP_SOLC:-0}"
+COMPILER_INPUT_MODE="${INPUT_MODE}"
 
 validate_toggle "MORPHO_VERITY_SKIP_BUILD" "${SKIP_BUILD}"
 validate_toggle "MORPHO_VERITY_SKIP_SOLC" "${SKIP_SOLC}"
@@ -37,6 +38,10 @@ validate_toggle "MORPHO_VERITY_SKIP_SOLC" "${SKIP_SOLC}"
 if [[ "${INPUT_MODE}" != "model" && "${INPUT_MODE}" != "edsl" ]]; then
   echo "ERROR: MORPHO_VERITY_INPUT_MODE must be 'model' or 'edsl' (got: ${INPUT_MODE})"
   exit 2
+fi
+
+if [[ "${INPUT_MODE}" == "model" ]]; then
+  COMPILER_INPUT_MODE="edsl"
 fi
 
 default_pack=""
@@ -74,12 +79,15 @@ if [[ "${SKIP_BUILD}" != "1" ]]; then
 fi
 
 echo "Running Morpho Verity compiler..."
-compiler_args=(--output "${OUT_DIR}" --abi-output "${OUT_DIR}" --input "${INPUT_MODE}" --link "${HASH_LIB}" --verbose)
+compiler_args=(--output "${OUT_DIR}" --abi-output "${OUT_DIR}" --input "${COMPILER_INPUT_MODE}" --link "${HASH_LIB}" --verbose)
 if [[ -n "${PARITY_PACK}" ]]; then
   compiler_args+=(--parity-pack "${PARITY_PACK}")
   echo "Using Verity parity pack: ${PARITY_PACK}"
 fi
-echo "Using input mode: ${INPUT_MODE}"
+if [[ "${INPUT_MODE}" == "model" ]]; then
+  echo "Using input mode alias: model -> edsl"
+fi
+echo "Using input mode: ${COMPILER_INPUT_MODE}"
 (cd "${ROOT_DIR}" && lake exe morpho-verity-compiler "${compiler_args[@]}")
 
 if [[ ! -s "${MORPHO_YUL}" ]]; then


### PR DESCRIPTION
## Summary
- canonicalize `MORPHO_VERITY_INPUT_MODE=model` to compiler-facing `edsl` in `prepare_verity_morpho_artifact.sh`
- keep `model` accepted as a compatibility alias while enforcing one internal lowering path
- add regression test asserting alias canonicalization and diagnostics
- update README fail-closed note to explicitly state script-level canonicalization

## Why
The Lean compiler path is already canonicalized to generalized `edsl`; this removes remaining shell-level dual-path ambiguity and reduces migration scope without breaking compatibility.

## Validation
- `./scripts/test_prepare_verity_morpho_artifact.sh`
- `./scripts/test_check_input_mode_parity.sh`
- `./scripts/test_check_toolchain_readiness.sh`
- `./scripts/test_install_foundry.sh`
- `lake build Morpho.Compiler.Main Morpho.Compiler.MainTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to build/compile scripting behavior and adds a regression test; main risk is unintended behavior change for workflows relying on passing `model` through to the compiler.
> 
> **Overview**
> `prepare_verity_morpho_artifact.sh` now treats `MORPHO_VERITY_INPUT_MODE=model` as a *compatibility alias* and always invokes the compiler with `--input edsl`, emitting a clear diagnostic when the alias is used.
> 
> Adds a regression test in `test_prepare_verity_morpho_artifact.sh` to assert the alias is canonicalized (including expected output/artifact contents), and updates the README fail-closed notes to explicitly document this canonicalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b654a8dd84f6da1de4f003a4516a6050b06a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->