### PR TITLE
Refactor to edsl-only boundary and stabilize artifact CI gates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Run Yul identity report unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Yul identity report unit tests" -- python3 scripts/test_report_yul_identity_gap.py
 
-      - name: Run input-mode parity script unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Input-mode parity script unit tests" -- ./scripts/test_check_input_mode_parity.sh
+      - name: Run artifact-gate script unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact-gate script unit tests" -- ./scripts/test_check_input_mode_parity.sh
 
       - name: Run artifact-prep script unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact-prep script unit tests" -- ./scripts/test_prepare_verity_morpho_artifact.sh
@@ -115,7 +115,7 @@ jobs:
     name: Yul identity gap report (Solidity vs Verity)
     runs-on: ubuntu-latest
     needs: [verity-proofs, parity-target]
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -173,9 +173,9 @@ jobs:
       - name: Generate Yul identity report
         run: ./scripts/run_with_timeout.sh MORPHO_YUL_IDENTITY_TIMEOUT_SEC 1500 "Yul identity report" -- python3 scripts/report_yul_identity_gap.py --max-diff-lines 12000 --enforce-unsupported-manifest
         env:
-          MORPHO_YUL_IDENTITY_TIMEOUT_SEC: "3300"
+          MORPHO_YUL_IDENTITY_TIMEOUT_SEC: "4200"
           MORPHO_SOLIDITY_IR_BUILD_TIMEOUT_SEC: "900"
-          MORPHO_VERITY_PREP_TIMEOUT_SEC: "1800"
+          MORPHO_VERITY_PREP_TIMEOUT_SEC: "3000"
 
       - name: Upload Yul identity artifacts
         if: always()
@@ -282,11 +282,11 @@ jobs:
       - name: Check full toolchain readiness
         run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
-      - name: Compile Morpho Verity artifact and enforce model/edsl parity
-        run: ./scripts/run_with_timeout.sh MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC 2400 "Input-mode parity gate" -- ./scripts/check_input_mode_parity.sh
+      - name: Compile Morpho Verity artifact and enforce artifact gate
+        run: ./scripts/run_with_timeout.sh MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC 2400 "Artifact preflight gate" -- ./scripts/check_input_mode_parity.sh
         env:
-          MORPHO_VERITY_PREP_TIMEOUT_SEC: "1200"
-          MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC: "3000"
+          MORPHO_VERITY_PREP_TIMEOUT_SEC: "2400"
+          MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC: "3600"
 
       - name: Run Verity artifact smoke tests
         working-directory: verity-foundry

--- a/Morpho/Compiler/MainTest.lean
+++ b/Morpho/Compiler/MainTest.lean
@@ -37,46 +37,26 @@ private def fileExists (path : String) : IO Bool := do
     pure false
 
 #eval! do
-  expectErrorContains "missing --input value" ["--input"] "Missing value for --input"
-  expectErrorContains "invalid --input value" ["--input", "ast"] "Invalid value for --input: ast"
+  expectErrorContains "input mode flag removed" ["--input", "edsl"] "Unknown argument: --input"
   expectErrorContains "missing --link value" ["--link"] "Missing value for --link"
   expectErrorContains "missing --abi-output value" ["--abi-output"] "Missing value for --abi-output"
   expectErrorContains "unknown argument still reported" ["--definitely-unknown-flag"] "Unknown argument: --definitely-unknown-flag"
 
   let nonce ← IO.monoMsNow
-  let modelOutDir := s!"/tmp/morpho-main-test-{nonce}-model-out"
   let edslOutDir := s!"/tmp/morpho-main-test-{nonce}-edsl-out"
-  let modelAbiDir := s!"/tmp/morpho-main-test-{nonce}-model-abi"
   let edslAbiDir := s!"/tmp/morpho-main-test-{nonce}-edsl-abi"
-  IO.FS.createDirAll modelOutDir
   IO.FS.createDirAll edslOutDir
-  IO.FS.createDirAll modelAbiDir
   IO.FS.createDirAll edslAbiDir
 
   let hashLib := "compiler/external-libs/MarketParamsHash.yul"
   Morpho.Compiler.Main.main
-    ["--input", "model", "--output", modelOutDir, "--abi-output", modelAbiDir, "--link", hashLib]
-  Morpho.Compiler.Main.main
-    ["--input", "edsl", "--output", edslOutDir, "--abi-output", edslAbiDir, "--link", hashLib]
+    ["--output", edslOutDir, "--abi-output", edslAbiDir, "--link", hashLib]
 
-  let modelYulPath := s!"{modelOutDir}/Morpho.yul"
   let edslYulPath := s!"{edslOutDir}/Morpho.yul"
-  let modelExists ← fileExists modelYulPath
   let edslExists ← fileExists edslYulPath
-  expectTrue "model mode emits Morpho.yul" modelExists
   expectTrue "edsl mode emits Morpho.yul" edslExists
-  let modelAbiPath := s!"{modelAbiDir}/Morpho.abi.json"
   let edslAbiPath := s!"{edslAbiDir}/Morpho.abi.json"
-  let modelAbiExists ← fileExists modelAbiPath
   let edslAbiExists ← fileExists edslAbiPath
-  expectTrue "model mode emits Morpho.abi.json" modelAbiExists
   expectTrue "edsl mode emits Morpho.abi.json" edslAbiExists
-
-  let modelYul ← IO.FS.readFile modelYulPath
-  let edslYul ← IO.FS.readFile edslYulPath
-  expectTrue "model and edsl modes emit identical Morpho.yul" (modelYul == edslYul)
-  let modelAbi ← IO.FS.readFile modelAbiPath
-  let edslAbi ← IO.FS.readFile edslAbiPath
-  expectTrue "model and edsl modes emit identical Morpho.abi.json" (modelAbi == edslAbi)
 
 end Morpho.Compiler.MainTest

--- a/scripts/check_input_mode_parity.sh
+++ b/scripts/check_input_mode_parity.sh
@@ -3,131 +3,39 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUN_WITH_TIMEOUT="${ROOT_DIR}/scripts/run_with_timeout.sh"
-PARITY_OUT_DIR="${MORPHO_VERITY_PARITY_OUT_DIR:-}"
+OUT_DIR="${MORPHO_VERITY_PARITY_OUT_DIR:-}"
 TMP_DIR=""
-ABI_MODEL_CANONICAL=""
-ABI_EDSL_CANONICAL=""
 
 cleanup() {
   if [[ -n "${TMP_DIR}" ]]; then
     rm -rf "${TMP_DIR}"
   fi
-  if [[ -n "${ABI_MODEL_CANONICAL}" ]]; then
-    rm -f "${ABI_MODEL_CANONICAL}"
-  fi
-  if [[ -n "${ABI_EDSL_CANONICAL}" ]]; then
-    rm -f "${ABI_EDSL_CANONICAL}"
-  fi
 }
 
 trap cleanup EXIT
 
-run_prepare() {
-  local mode="$1"
-  local out_dir="$2"
-  local skip_build="${3:-0}"
-  local -a prepare_cmd=(
-    "${RUN_WITH_TIMEOUT}"
-    MORPHO_VERITY_PREP_TIMEOUT_SEC
-    900
-    "Prepare ${mode} artifact"
-    --
-    "${ROOT_DIR}/scripts/prepare_verity_morpho_artifact.sh"
-  )
-
-  if [[ "${skip_build}" == "1" ]]; then
-    MORPHO_VERITY_SKIP_BUILD="1" \
-    MORPHO_VERITY_OUT_DIR="${out_dir}" \
-    MORPHO_VERITY_INPUT_MODE="${mode}" \
-      "${prepare_cmd[@]}"
-  else
-    MORPHO_VERITY_OUT_DIR="${out_dir}" \
-    MORPHO_VERITY_INPUT_MODE="${mode}" \
-      "${prepare_cmd[@]}"
-  fi
-}
-
-canonicalize_abi() {
-  local abi_path="$1"
-  local out_path="$2"
-  local label="$3"
-
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "ERROR: python3 is required to canonicalize ABI artifacts for parity checks"
-    exit 1
-  fi
-
-  if ! python3 - "${abi_path}" "${out_path}" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], "r", encoding="utf-8") as src:
-        data = json.load(src)
-except json.JSONDecodeError as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(2)
-
-with open(sys.argv[2], "w", encoding="utf-8") as dst:
-    json.dump(data, dst, sort_keys=True, separators=(",", ":"))
-    dst.write("\n")
-PY
-  then
-    echo "ERROR: failed to canonicalize ${label} ABI artifact: ${abi_path}"
-    exit 1
-  fi
-}
-
-if [[ -n "${PARITY_OUT_DIR}" ]]; then
-  mkdir -p "${PARITY_OUT_DIR}"
-  MODEL_OUT="${PARITY_OUT_DIR}/model"
-  EDSL_OUT="${PARITY_OUT_DIR}/edsl"
-  rm -rf "${MODEL_OUT}" "${EDSL_OUT}"
-  mkdir -p "${MODEL_OUT}" "${EDSL_OUT}"
+if [[ -n "${OUT_DIR}" ]]; then
+  mkdir -p "${OUT_DIR}/edsl"
+  rm -rf "${OUT_DIR}/edsl"
+  mkdir -p "${OUT_DIR}/edsl"
+  TARGET_OUT="${OUT_DIR}/edsl"
 else
   TMP_DIR="$(mktemp -d)"
-  MODEL_OUT="${TMP_DIR}/model"
-  EDSL_OUT="${TMP_DIR}/edsl"
+  TARGET_OUT="${TMP_DIR}/edsl"
 fi
 
-echo "Checking Morpho compiler input-mode parity (model vs edsl)..."
+echo "Preparing Morpho compiler artifact (edsl-only)..."
+MORPHO_VERITY_OUT_DIR="${TARGET_OUT}" \
+  MORPHO_VERITY_INPUT_MODE="edsl" \
+  "${RUN_WITH_TIMEOUT}" MORPHO_VERITY_PREP_TIMEOUT_SEC 900 \
+    "Prepare edsl artifact" -- \
+    "${ROOT_DIR}/scripts/prepare_verity_morpho_artifact.sh"
 
-run_prepare "model" "${MODEL_OUT}" "0"
-run_prepare "edsl" "${EDSL_OUT}" "1"
-
-MODEL_YUL="${MODEL_OUT}/Morpho.yul"
-EDSL_YUL="${EDSL_OUT}/Morpho.yul"
-MODEL_BIN="${MODEL_OUT}/Morpho.bin"
-EDSL_BIN="${EDSL_OUT}/Morpho.bin"
-MODEL_ABI="${MODEL_OUT}/Morpho.abi.json"
-EDSL_ABI="${EDSL_OUT}/Morpho.abi.json"
-
-for artifact in "${MODEL_YUL}" "${EDSL_YUL}" "${MODEL_BIN}" "${EDSL_BIN}" "${MODEL_ABI}" "${EDSL_ABI}"; do
+for artifact in "${TARGET_OUT}/Morpho.yul" "${TARGET_OUT}/Morpho.bin" "${TARGET_OUT}/Morpho.abi.json"; do
   if [[ ! -s "${artifact}" ]]; then
     echo "ERROR: missing or empty artifact: ${artifact}"
     exit 1
   fi
 done
 
-if ! cmp -s "${MODEL_YUL}" "${EDSL_YUL}"; then
-  echo "ERROR: model vs edsl Yul artifacts differ"
-  diff -u "${MODEL_YUL}" "${EDSL_YUL}" | head -n 200 || true
-  exit 1
-fi
-
-if ! cmp -s "${MODEL_BIN}" "${EDSL_BIN}"; then
-  echo "ERROR: model vs edsl bytecode artifacts differ"
-  exit 1
-fi
-
-ABI_MODEL_CANONICAL="$(mktemp)"
-ABI_EDSL_CANONICAL="$(mktemp)"
-canonicalize_abi "${MODEL_ABI}" "${ABI_MODEL_CANONICAL}" "model"
-canonicalize_abi "${EDSL_ABI}" "${ABI_EDSL_CANONICAL}" "edsl"
-
-if ! cmp -s "${ABI_MODEL_CANONICAL}" "${ABI_EDSL_CANONICAL}"; then
-  echo "ERROR: model vs edsl ABI artifacts differ semantically"
-  exit 1
-fi
-
-echo "Input-mode parity passed: model and edsl Yul/bytecode match byte-for-byte and ABI matches semantically."
+echo "Artifact preparation passed: Morpho.yul, Morpho.bin, and Morpho.abi.json are present."

--- a/scripts/prepare_verity_morpho_artifact.sh
+++ b/scripts/prepare_verity_morpho_artifact.sh
@@ -27,21 +27,15 @@ validate_toggle() {
   fi
 }
 
-INPUT_MODE="${MORPHO_VERITY_INPUT_MODE:-edsl}"
 SKIP_BUILD="${MORPHO_VERITY_SKIP_BUILD:-0}"
 SKIP_SOLC="${MORPHO_VERITY_SKIP_SOLC:-0}"
-COMPILER_INPUT_MODE="${INPUT_MODE}"
 
 validate_toggle "MORPHO_VERITY_SKIP_BUILD" "${SKIP_BUILD}"
 validate_toggle "MORPHO_VERITY_SKIP_SOLC" "${SKIP_SOLC}"
 
-if [[ "${INPUT_MODE}" != "model" && "${INPUT_MODE}" != "edsl" ]]; then
-  echo "ERROR: MORPHO_VERITY_INPUT_MODE must be 'model' or 'edsl' (got: ${INPUT_MODE})"
+if [[ -n "${MORPHO_VERITY_INPUT_MODE:-}" && "${MORPHO_VERITY_INPUT_MODE}" != "edsl" ]]; then
+  echo "ERROR: MORPHO_VERITY_INPUT_MODE only supports 'edsl' (got: ${MORPHO_VERITY_INPUT_MODE})"
   exit 2
-fi
-
-if [[ "${INPUT_MODE}" == "model" ]]; then
-  COMPILER_INPUT_MODE="edsl"
 fi
 
 default_pack=""
@@ -79,15 +73,12 @@ if [[ "${SKIP_BUILD}" != "1" ]]; then
 fi
 
 echo "Running Morpho Verity compiler..."
-compiler_args=(--output "${OUT_DIR}" --abi-output "${OUT_DIR}" --input "${COMPILER_INPUT_MODE}" --link "${HASH_LIB}" --verbose)
+compiler_args=(--output "${OUT_DIR}" --abi-output "${OUT_DIR}" --link "${HASH_LIB}" --verbose)
 if [[ -n "${PARITY_PACK}" ]]; then
   compiler_args+=(--parity-pack "${PARITY_PACK}")
   echo "Using Verity parity pack: ${PARITY_PACK}"
 fi
-if [[ "${INPUT_MODE}" == "model" ]]; then
-  echo "Using input mode alias: model -> edsl"
-fi
-echo "Using input mode: ${COMPILER_INPUT_MODE}"
+echo "Using input mode: edsl"
 (cd "${ROOT_DIR}" && lake exe morpho-verity-compiler "${compiler_args[@]}")
 
 if [[ ! -s "${MORPHO_YUL}" ]]; then

--- a/scripts/run_morpho_blue_parity.sh
+++ b/scripts/run_morpho_blue_parity.sh
@@ -38,7 +38,7 @@ if [[ "${SKIP_PARITY_PREFLIGHT}" == "1" ]]; then
     echo "Set MORPHO_VERITY_ALLOW_LOCAL_PARITY_PREFLIGHT_SKIP=1 only for explicit local debugging."
     exit 1
   fi
-  echo "Skipping input-mode parity preflight (MORPHO_VERITY_SKIP_PARITY_PREFLIGHT=1)."
+  echo "Skipping artifact preflight gate (MORPHO_VERITY_SKIP_PARITY_PREFLIGHT=1)."
   MORPHO_VERITY_OUT_DIR="${PARITY_OUT_DIR}/edsl" \
   MORPHO_VERITY_INPUT_MODE="edsl" \
     "${RUN_WITH_TIMEOUT}" MORPHO_VERITY_PREP_TIMEOUT_SEC 900 \
@@ -48,7 +48,7 @@ else
   # Fast fail-closed guard before the long differential suite.
   MORPHO_VERITY_PARITY_OUT_DIR="${PARITY_OUT_DIR}" \
     "${RUN_WITH_TIMEOUT}" MORPHO_VERITY_PARITY_PREFLIGHT_TIMEOUT_SEC 1800 \
-      "Input-mode parity preflight" -- \
+      "Artifact preflight gate" -- \
       "${ROOT_DIR}/scripts/check_input_mode_parity.sh"
 fi
 

--- a/scripts/test_check_input_mode_parity.sh
+++ b/scripts/test_check_input_mode_parity.sh
@@ -13,51 +13,6 @@ assert_contains() {
   fi
 }
 
-build_path_without_timeout() {
-  local path_dir="$1"
-  local -a commands=(
-    bash
-    cmp
-    diff
-    dirname
-    head
-    mkdir
-    mktemp
-    python3
-    rm
-    sleep
-  )
-
-  mkdir -p "${path_dir}"
-  for cmd in "${commands[@]}"; do
-    local source_cmd
-    source_cmd="$(command -v "${cmd}")"
-    ln -s "${source_cmd}" "${path_dir}/${cmd}"
-  done
-}
-
-build_path_without_python3() {
-  local path_dir="$1"
-  local -a commands=(
-    bash
-    cmp
-    diff
-    dirname
-    head
-    mkdir
-    mktemp
-    rm
-    sleep
-  )
-
-  mkdir -p "${path_dir}"
-  for cmd in "${commands[@]}"; do
-    local source_cmd
-    source_cmd="$(command -v "${cmd}")"
-    ln -s "${source_cmd}" "${path_dir}/${cmd}"
-  done
-}
-
 make_fake_repo() {
   local fake_root="$1"
   mkdir -p "${fake_root}/scripts"
@@ -71,53 +26,17 @@ make_fake_repo() {
 set -euo pipefail
 out="${MORPHO_VERITY_OUT_DIR:?MORPHO_VERITY_OUT_DIR is required}"
 mkdir -p "${out}"
-mode="${MORPHO_VERITY_INPUT_MODE:-unknown}"
-sleep_secs="${FAKE_SLEEP_SECS:-0}"
-if [[ "${sleep_secs}" != "0" ]]; then
-  sleep "${sleep_secs}"
-fi
-
-if [[ "${mode}" == "model" ]]; then
-  printf '%s\n' "shared-yul" > "${out}/Morpho.yul"
-  printf '%s\n' "shared-bin" > "${out}/Morpho.bin"
-  if [[ "${FAKE_INVALID_MODEL_ABI:-0}" == "1" ]]; then
-    printf '%s\n' '{"invalid":' > "${out}/Morpho.abi.json"
-    exit 0
-  fi
-  if [[ "${FAKE_ABI_FORMAT_DRIFT:-0}" == "1" ]]; then
-    printf '%s\n' '[{"type":"function","name":"same"}]' > "${out}/Morpho.abi.json"
-  else
-    printf '%s\n' "[]" > "${out}/Morpho.abi.json"
-  fi
+if [[ "${FAKE_MISSING_ARTIFACTS:-0}" == "1" ]]; then
   exit 0
 fi
-
-if [[ "${FAKE_MISMATCH_YUL:-0}" == "1" ]]; then
-  printf '%s\n' "different-yul" > "${out}/Morpho.yul"
-else
-  printf '%s\n' "shared-yul" > "${out}/Morpho.yul"
-fi
-if [[ "${FAKE_MISMATCH_BIN:-0}" == "1" ]]; then
-  printf '%s\n' "different-bin" > "${out}/Morpho.bin"
-else
-  printf '%s\n' "shared-bin" > "${out}/Morpho.bin"
-fi
-if [[ "${FAKE_MISSING_ABI:-0}" != "1" ]]; then
-  if [[ "${FAKE_INVALID_EDSL_ABI:-0}" == "1" ]]; then
-    printf '%s\n' '{"invalid":' > "${out}/Morpho.abi.json"
-  elif [[ "${FAKE_MISMATCH_ABI:-0}" == "1" ]]; then
-    printf '%s\n' "[{\"type\":\"function\",\"name\":\"different\"}]" > "${out}/Morpho.abi.json"
-  elif [[ "${FAKE_ABI_FORMAT_DRIFT:-0}" == "1" ]]; then
-    printf '%s\n' '[ { "name":"same" , "type":"function" } ]' > "${out}/Morpho.abi.json"
-  else
-  printf '%s\n' "[]" > "${out}/Morpho.abi.json"
-  fi
-fi
+printf '%s\n' "fake-yul-edsl" > "${out}/Morpho.yul"
+printf '%s\n' "fake-bin-edsl" > "${out}/Morpho.bin"
+printf '%s\n' "[]" > "${out}/Morpho.abi.json"
 EOF
   chmod +x "${fake_root}/scripts/prepare_verity_morpho_artifact.sh"
 }
 
-test_success_when_model_and_edsl_artifacts_match() {
+test_success_when_edsl_artifacts_exist() {
   local fake_root out_dir
   fake_root="$(mktemp -d)"
   out_dir="$(mktemp -d)"
@@ -126,107 +45,25 @@ test_success_when_model_and_edsl_artifacts_match() {
 
   (
     cd "${fake_root}"
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
+    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" ./scripts/check_input_mode_parity.sh
   )
 
-  [[ -s "${out_dir}/model/Morpho.yul" ]]
   [[ -s "${out_dir}/edsl/Morpho.yul" ]]
-  [[ -s "${out_dir}/model/Morpho.bin" ]]
   [[ -s "${out_dir}/edsl/Morpho.bin" ]]
-  [[ -s "${out_dir}/model/Morpho.abi.json" ]]
   [[ -s "${out_dir}/edsl/Morpho.abi.json" ]]
 }
 
-test_fail_closed_on_yul_mismatch() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_MISMATCH_YUL=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected Yul mismatch to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: model vs edsl Yul artifacts differ" "${output_file}"
-}
-
-test_fail_closed_on_bytecode_mismatch() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_MISMATCH_BIN=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected bytecode mismatch to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: model vs edsl bytecode artifacts differ" "${output_file}"
-}
-
-test_fail_closed_on_abi_mismatch() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_MISMATCH_ABI=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected ABI mismatch to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: model vs edsl ABI artifacts differ" "${output_file}"
-}
-
 test_fail_closed_on_missing_artifact() {
-  local fake_root output_file out_dir
+  local fake_root output_file
   fake_root="$(mktemp -d)"
   output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
+  trap 'rm -rf "${fake_root}" "${output_file}"' RETURN
   make_fake_repo "${fake_root}"
 
   set +e
   (
     cd "${fake_root}"
-    FAKE_MISSING_ABI=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
+    FAKE_MISSING_ARTIFACTS=1 ./scripts/check_input_mode_parity.sh
   ) >"${output_file}" 2>&1
   local status=$?
   set -e
@@ -235,197 +72,10 @@ test_fail_closed_on_missing_artifact() {
     echo "ASSERTION FAILED: expected missing artifact to fail"
     exit 1
   fi
-  assert_contains "ERROR: missing or empty artifact" "${output_file}"
+  assert_contains "ERROR: missing or empty artifact:" "${output_file}"
 }
 
-test_fail_closed_on_invalid_model_abi_json() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_INVALID_MODEL_ABI=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected invalid model ABI JSON to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: failed to canonicalize model ABI artifact" "${output_file}"
-}
-
-test_fail_closed_on_invalid_edsl_abi_json() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_INVALID_EDSL_ABI=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected invalid edsl ABI JSON to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: failed to canonicalize edsl ABI artifact" "${output_file}"
-}
-
-test_success_on_abi_formatting_drift() {
-  local fake_root out_dir
-  fake_root="$(mktemp -d)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  (
-    cd "${fake_root}"
-    FAKE_ABI_FORMAT_DRIFT=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  )
-
-  [[ -s "${out_dir}/model/Morpho.abi.json" ]]
-  [[ -s "${out_dir}/edsl/Morpho.abi.json" ]]
-}
-
-test_fail_closed_on_prepare_timeout() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    FAKE_SLEEP_SECS=2 \
-    MORPHO_VERITY_PREP_TIMEOUT_SEC=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected prepare timeout to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: Prepare model artifact timed out after 1s" "${output_file}"
-}
-
-test_fail_closed_on_invalid_prepare_timeout_value() {
-  local fake_root output_file out_dir
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}"' RETURN
-  make_fake_repo "${fake_root}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    MORPHO_VERITY_PREP_TIMEOUT_SEC=oops \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected invalid timeout value to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: MORPHO_VERITY_PREP_TIMEOUT_SEC must be a non-negative integer (got: oops)" "${output_file}"
-}
-
-test_fail_closed_when_timeout_missing_but_enabled() {
-  local fake_root output_file out_dir restricted_path
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  restricted_path="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}" "${restricted_path}"' RETURN
-  make_fake_repo "${fake_root}"
-  build_path_without_timeout "${restricted_path}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    hash -r
-    PATH="${restricted_path}" \
-    MORPHO_VERITY_PREP_TIMEOUT_SEC=1 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected missing timeout command to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: timeout command is required when MORPHO_VERITY_PREP_TIMEOUT_SEC is greater than zero" "${output_file}"
-}
-
-test_fail_closed_when_python3_missing() {
-  local fake_root output_file out_dir restricted_path
-  fake_root="$(mktemp -d)"
-  output_file="$(mktemp)"
-  out_dir="$(mktemp -d)"
-  restricted_path="$(mktemp -d)"
-  trap 'rm -rf "${fake_root}" "${output_file}" "${out_dir}" "${restricted_path}"' RETURN
-  make_fake_repo "${fake_root}"
-  build_path_without_python3 "${restricted_path}"
-
-  set +e
-  (
-    cd "${fake_root}"
-    hash -r
-    PATH="${restricted_path}" \
-    MORPHO_VERITY_PREP_TIMEOUT_SEC=0 \
-    MORPHO_VERITY_PARITY_OUT_DIR="${out_dir}" \
-      ./scripts/check_input_mode_parity.sh
-  ) >"${output_file}" 2>&1
-  local status=$?
-  set -e
-
-  if [[ "${status}" -eq 0 ]]; then
-    echo "ASSERTION FAILED: expected missing python3 to fail"
-    exit 1
-  fi
-  assert_contains "ERROR: python3 is required to canonicalize ABI artifacts for parity checks" "${output_file}"
-}
-
-test_success_when_model_and_edsl_artifacts_match
-test_success_on_abi_formatting_drift
-test_fail_closed_on_yul_mismatch
-test_fail_closed_on_bytecode_mismatch
-test_fail_closed_on_abi_mismatch
+test_success_when_edsl_artifacts_exist
 test_fail_closed_on_missing_artifact
-test_fail_closed_on_invalid_model_abi_json
-test_fail_closed_on_invalid_edsl_abi_json
-test_fail_closed_on_prepare_timeout
-test_fail_closed_on_invalid_prepare_timeout_value
-test_fail_closed_when_timeout_missing_but_enabled
-test_fail_closed_when_python3_missing
 
 echo "check_input_mode_parity.sh tests passed"

--- a/scripts/test_run_morpho_blue_parity.sh
+++ b/scripts/test_run_morpho_blue_parity.sh
@@ -461,7 +461,7 @@ test_parity_preflight_timeout_fails_closed() {
     echo "ASSERTION FAILED: expected parity-preflight timeout to fail"
     exit 1
   fi
-  assert_contains "ERROR: Input-mode parity preflight timed out after 1s" "${output_file}"
+  assert_contains "ERROR: Artifact preflight gate timed out after 1s" "${output_file}"
 }
 
 test_fail_closed_on_invalid_prep_timeout_value_in_skip_mode() {


### PR DESCRIPTION
## Summary
- enforce an EDSL-only compiler boundary in Morpho compiler CLI (`--input` removed)
- switch artifact preflight to a single edsl artifact gate (no model-vs-edsl dual compilation)
- update prep script to reject non-`edsl` `MORPHO_VERITY_INPUT_MODE`
- harden CI timeout budgets for long artifact-prep lanes (`verity-compiled-tests`, `yul-identity-report`)
- sync tests/docs to the edsl-only behavior

## Why
This removes dual-mode boundary drift and directly targets current CI failures (`Prepare model artifact timed out after 1200s`, `Prepare Verity artifact for Yul identity report timed out after 1800s`) by eliminating redundant mode parity work and raising nested timeout budgets where needed.

## Validation
- `lake build Morpho.Compiler.Main Morpho.Compiler.MainTest`
- `./scripts/test_prepare_verity_morpho_artifact.sh`
- `./scripts/test_check_input_mode_parity.sh`
- `./scripts/test_run_morpho_blue_parity.sh`
- `./scripts/test_check_toolchain_readiness.sh`

Issue: #31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the compiler CLI contract and CI artifact gating behavior, which could break downstream tooling or weaken parity validation if assumptions were wrong. Changes are largely isolated to build/test automation and documentation.
> 
> **Overview**
> **Enforces an EDSL-only compilation boundary.** The `morpho-verity-compiler` CLI drops the `--input` flag and always reports/uses `edsl`, with `MainTest.lean` updated accordingly.
> 
> **Simplifies CI preflight from parity to artifact readiness.** `check_input_mode_parity.sh` is refactored from dual `model`/`edsl` compilation + byte/ABI comparisons into a single `edsl` artifact build that only checks `Morpho.yul`, `Morpho.bin`, and `Morpho.abi.json` exist and are non-empty; `prepare_verity_morpho_artifact.sh` now rejects `MORPHO_VERITY_INPUT_MODE` values other than `edsl`.
> 
> **Stabilizes pipelines and messaging.** The workflow renames the unit test lane to “artifact-gate”, updates preflight labels in `run_morpho_blue_parity.sh`, increases nested timeouts for `yul-identity-report` and `verity-compiled-tests`, and syncs README + shell tests to the new gate semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f66cfbac2e6fe81d84be046ed30bc91744926d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->