### PR TITLE
Parity cleanup: enforce EDSL-only naming and artifact-mode wording

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Validate CI timeout defaults sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI timeout defaults sync" -- python3 scripts/check_ci_timeout_defaults.py
 
+      - name: Validate parity EDSL-only naming
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate parity EDSL-only naming" -- python3 scripts/check_parity_edsl_naming.py
+
       - name: Run parity-target parser regression tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity-target parser regression tests" -- python3 scripts/test_check_parity_target.py
 
@@ -114,6 +117,9 @@ jobs:
 
       - name: Run CI timeout defaults unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI timeout defaults unit tests" -- python3 scripts/test_check_ci_timeout_defaults.py
+
+      - name: Run parity EDSL-only naming unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity EDSL-only naming unit tests" -- python3 scripts/test_check_parity_edsl_naming.py
 
       - name: Run artifact-gate script unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact-gate script unit tests" -- ./scripts/test_check_input_mode_parity.sh

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Build the Morpho Verity artifact:
 
 Artifact preparation is fail-closed for invalid toggle values and missing required tooling:
 - `MORPHO_VERITY_SKIP_BUILD` / `MORPHO_VERITY_SKIP_SOLC` must be `0` or `1`.
-- `MORPHO_VERITY_INPUT_MODE` may be omitted or set to `edsl` only.
+- `MORPHO_VERITY_ARTIFACT_MODE` may be omitted or set to `edsl` only.
+- `MORPHO_VERITY_INPUT_MODE` is a legacy alias; when both are set they must match.
 - `python3` is required to read `config/parity-target.json` when present.
 - `config/parity-target.json` must include a non-empty `verity.parityPackId`.
 - `compiler/external-libs/MarketParamsHash.yul` must be present.

--- a/docs/RELEASE_CRITERIA.md
+++ b/docs/RELEASE_CRITERIA.md
@@ -14,6 +14,7 @@ Partially enforced:
 5. `yul-identity-report` emits structural AST diagnostics in CI artifacts.
 6. `macro-migration-blockers` drift gate is enforced in CI (`scripts/check_macro_migration_blockers.py`).
 7. Long differential lane reuses a verified EDSL artifact bundle from `verity-compiled-tests` (reduced duplicate prep/timeout surface).
+8. EDSL-only parity naming gate is enforced in CI (`scripts/check_parity_edsl_naming.py`).
 
 Not yet enforced:
 1. strict `yul-identity-check` (zero structural AST mismatch for supported fragment).

--- a/scripts/check_input_mode_parity.sh
+++ b/scripts/check_input_mode_parity.sh
@@ -26,7 +26,7 @@ fi
 
 echo "Preparing Morpho compiler artifact (edsl-only)..."
 MORPHO_VERITY_OUT_DIR="${TARGET_OUT}" \
-  MORPHO_VERITY_INPUT_MODE="edsl" \
+  MORPHO_VERITY_ARTIFACT_MODE="edsl" \
   "${RUN_WITH_TIMEOUT}" MORPHO_VERITY_PREP_TIMEOUT_SEC 900 \
     "Prepare edsl artifact" -- \
     "${ROOT_DIR}/scripts/prepare_verity_morpho_artifact.sh"

--- a/scripts/check_parity_edsl_naming.py
+++ b/scripts/check_parity_edsl_naming.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Fail-closed guard for EDSL-only parity naming."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TARGETS = [
+  ROOT / "scripts" / "prepare_verity_morpho_artifact.sh",
+  ROOT / "scripts" / "check_input_mode_parity.sh",
+  ROOT / "scripts" / "run_morpho_blue_parity.sh",
+  ROOT / "README.md",
+  ROOT / "docs" / "PARITY_TARGET.md",
+  ROOT / "docs" / "RELEASE_CRITERIA.md",
+  ROOT / ".github" / "workflows" / "verify.yml",
+]
+FORBIDDEN = [
+  (re.compile(r"/model/"), "legacy parity fixture path '/model/'"),
+  (re.compile(r"\binput mode\b", re.IGNORECASE), "legacy wording 'input mode'"),
+]
+
+
+def main() -> None:
+  offenders: list[tuple[str, int, str]] = []
+
+  for path in TARGETS:
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+      for pattern, reason in FORBIDDEN:
+        if pattern.search(line):
+          offenders.append((str(path.relative_to(ROOT)), lineno, reason))
+
+  if offenders:
+    print("parity-edsl-naming check failed:", file=sys.stderr)
+    for rel, lineno, reason in offenders:
+      print(f"  {rel}:{lineno}: {reason}", file=sys.stderr)
+    print("Use EDSL-only parity naming in scripts/docs/workflows.", file=sys.stderr)
+    sys.exit(1)
+
+  print("parity-edsl-naming check: OK")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/prepare_verity_morpho_artifact.sh
+++ b/scripts/prepare_verity_morpho_artifact.sh
@@ -29,12 +29,23 @@ validate_toggle() {
 
 SKIP_BUILD="${MORPHO_VERITY_SKIP_BUILD:-0}"
 SKIP_SOLC="${MORPHO_VERITY_SKIP_SOLC:-0}"
+ARTIFACT_MODE="${MORPHO_VERITY_ARTIFACT_MODE:-}"
+LEGACY_INPUT_MODE="${MORPHO_VERITY_INPUT_MODE:-}"
 
 validate_toggle "MORPHO_VERITY_SKIP_BUILD" "${SKIP_BUILD}"
 validate_toggle "MORPHO_VERITY_SKIP_SOLC" "${SKIP_SOLC}"
 
-if [[ -n "${MORPHO_VERITY_INPUT_MODE:-}" && "${MORPHO_VERITY_INPUT_MODE}" != "edsl" ]]; then
-  echo "ERROR: MORPHO_VERITY_INPUT_MODE only supports 'edsl' (got: ${MORPHO_VERITY_INPUT_MODE})"
+if [[ -n "${ARTIFACT_MODE}" && -n "${LEGACY_INPUT_MODE}" && "${ARTIFACT_MODE}" != "${LEGACY_INPUT_MODE}" ]]; then
+  echo "ERROR: MORPHO_VERITY_ARTIFACT_MODE and MORPHO_VERITY_INPUT_MODE disagree (${ARTIFACT_MODE} vs ${LEGACY_INPUT_MODE})"
+  exit 2
+fi
+
+if [[ -z "${ARTIFACT_MODE}" ]]; then
+  ARTIFACT_MODE="${LEGACY_INPUT_MODE:-edsl}"
+fi
+
+if [[ "${ARTIFACT_MODE}" != "edsl" ]]; then
+  echo "ERROR: MORPHO_VERITY_ARTIFACT_MODE only supports 'edsl' (got: ${ARTIFACT_MODE})"
   exit 2
 fi
 
@@ -78,7 +89,7 @@ if [[ -n "${PARITY_PACK}" ]]; then
   compiler_args+=(--parity-pack "${PARITY_PACK}")
   echo "Using Verity parity pack: ${PARITY_PACK}"
 fi
-echo "Using input mode: edsl"
+echo "Using artifact mode: ${ARTIFACT_MODE}"
 (cd "${ROOT_DIR}" && lake exe morpho-verity-compiler "${compiler_args[@]}")
 
 if [[ ! -s "${MORPHO_YUL}" ]]; then

--- a/scripts/run_morpho_blue_parity.sh
+++ b/scripts/run_morpho_blue_parity.sh
@@ -50,7 +50,7 @@ elif [[ "${SKIP_PARITY_PREFLIGHT}" == "1" ]]; then
   fi
   echo "Skipping artifact preflight gate (MORPHO_VERITY_SKIP_PARITY_PREFLIGHT=1)."
   MORPHO_VERITY_OUT_DIR="${PARITY_OUT_DIR}/edsl" \
-  MORPHO_VERITY_INPUT_MODE="edsl" \
+  MORPHO_VERITY_ARTIFACT_MODE="edsl" \
     "${RUN_WITH_TIMEOUT}" MORPHO_VERITY_PREP_TIMEOUT_SEC 900 \
       "Prepare edsl artifact" -- \
       "${ROOT_DIR}/scripts/prepare_verity_morpho_artifact.sh"

--- a/scripts/test_check_parity_edsl_naming.py
+++ b/scripts/test_check_parity_edsl_naming.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Unit tests for parity EDSL-only naming checker."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_parity_edsl_naming.py"
+README = ROOT / "README.md"
+
+
+class CheckParityEdslNamingTests(unittest.TestCase):
+  def test_repo_naming_is_clean(self) -> None:
+    proc = subprocess.run(
+      ["python3", str(SCRIPT)],
+      cwd=ROOT,
+      capture_output=True,
+      text=True,
+      check=False,
+    )
+    self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+    self.assertIn("check: OK", proc.stdout)
+
+  def test_detects_legacy_wording(self) -> None:
+    original = README.read_text(encoding="utf-8")
+    try:
+      README.write_text(original + "\nlegacy input mode mention\n", encoding="utf-8")
+      proc = subprocess.run(
+        ["python3", str(SCRIPT)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+      )
+      self.assertNotEqual(proc.returncode, 0)
+      self.assertIn("README.md", proc.stderr)
+    finally:
+      README.write_text(original, encoding="utf-8")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/test_run_morpho_blue_parity.sh
+++ b/scripts/test_run_morpho_blue_parity.sh
@@ -40,10 +40,10 @@ if [[ "${sleep_secs}" != "0" ]]; then
   sleep "${sleep_secs}"
 fi
 if [[ "${missing_artifact}" != "yul" ]]; then
-  printf '%s\n' "fake-yul-${MORPHO_VERITY_INPUT_MODE:-unknown}" > "${out}/Morpho.yul"
+  printf '%s\n' "fake-yul-${MORPHO_VERITY_ARTIFACT_MODE:-unknown}" > "${out}/Morpho.yul"
 fi
 if [[ "${missing_artifact}" != "bin" ]]; then
-  printf '%s\n' "fake-bin-${MORPHO_VERITY_INPUT_MODE:-unknown}" > "${out}/Morpho.bin"
+  printf '%s\n' "fake-bin-${MORPHO_VERITY_ARTIFACT_MODE:-unknown}" > "${out}/Morpho.bin"
 fi
 if [[ "${missing_artifact}" != "abi" ]]; then
   printf '%s\n' "[]" > "${out}/Morpho.abi.json"


### PR DESCRIPTION
## Summary
Completes another `#40` cleanup slice by removing remaining transition-era parity wording and adding fail-closed CI enforcement.

### Changes
- Canonicalized runtime wording to **artifact mode** (`MORPHO_VERITY_ARTIFACT_MODE`) in parity-prep flow.
- Kept `MORPHO_VERITY_INPUT_MODE` as a strict legacy alias (fail-closed on mismatch when both vars are set).
- Updated parity runner to pass `MORPHO_VERITY_ARTIFACT_MODE=edsl`.
- Added fail-closed guard script:
  - `scripts/check_parity_edsl_naming.py`
  - blocks legacy `/model/` path fragments and `input mode` wording in parity runtime/docs/workflow surfaces.
- Added unit tests:
  - `scripts/test_check_parity_edsl_naming.py`
  - updated parity/prep regression tests for artifact-mode terminology + legacy alias compatibility.
- Wired new validate/test steps into `parity-target` CI job.
- Updated release criteria and README wording.

## Validation
- `python3 scripts/check_parity_edsl_naming.py`
- `python3 scripts/test_check_parity_edsl_naming.py`
- `./scripts/test_prepare_verity_morpho_artifact.sh`
- `./scripts/test_check_input_mode_parity.sh`
- `./scripts/test_run_morpho_blue_parity.sh`
- `./scripts/test_run_with_timeout.sh`
- `python3 scripts/test_check_parity_target.py`
- `lake build Morpho.Compiler.Main Morpho.Compiler.MainTest`

Refs #40.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/script gating and environment-variable naming, with compatibility preserved via a strict legacy alias check. Main risk is CI/prep failures if any remaining docs/scripts reference the old naming or if callers set mismatched mode variables.
> 
> **Overview**
> Standardizes the parity artifact-prep flow on **artifact mode** by introducing `MORPHO_VERITY_ARTIFACT_MODE` (EDSL-only) and treating `MORPHO_VERITY_INPUT_MODE` as a strict legacy alias that must match when both are set.
> 
> Adds a fail-closed `scripts/check_parity_edsl_naming.py` gate (with unit tests) that scans key scripts/docs/workflows for legacy `/model/` paths and the phrase *input mode*, and wires both the validator and its tests into the `parity-target` CI job. Documentation is updated to reflect the new env var and enforcement in release criteria/README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee8e09645478dc2a3dd5c3a532346104e361884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->