### PR TITLE
Harden #39: reuse verified artifacts in Yul identity lane

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -155,7 +155,7 @@ jobs:
   yul-identity-report:
     name: Yul identity gap report (Solidity vs Verity)
     runs-on: ubuntu-latest
-    needs: [verity-proofs, parity-target]
+    needs: [verity-proofs, parity-target, verity-compiled-tests]
     timeout-minutes: 75
     steps:
       - name: Checkout
@@ -214,11 +214,18 @@ jobs:
       - name: Check full toolchain readiness
         run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
+      - name: Download verified EDSL artifact bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: verity-edsl-artifacts
+          path: out/parity-shared
+
       - name: Generate Yul identity report
         run: ./scripts/run_with_timeout.sh MORPHO_YUL_IDENTITY_TIMEOUT_SEC 4200 "Yul identity report" -- python3 scripts/report_yul_identity_gap.py --max-diff-lines 12000 --enforce-unsupported-manifest
         env:
           MORPHO_SOLIDITY_IR_BUILD_TIMEOUT_SEC: "900"
           MORPHO_VERITY_PREP_TIMEOUT_SEC: "3000"
+          MORPHO_VERITY_PREPARED_ARTIFACT_DIR: out/parity-shared
 
       - name: Upload Yul identity artifacts
         if: always()

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Workflow long-lane commands also use fail-closed timeout guards via a shared tim
 - `0` disables timeout for each respective command
 The shared timeout wrapper enforces hard fail-closed termination (`timeout --kill-after=${MORPHO_TIMEOUT_KILL_AFTER_SEC:-30}s`) so TERM-ignoring subprocesses cannot hang CI indefinitely.
 `MORPHO_TIMEOUT_KILL_AFTER_SEC` must stay strictly greater than `0` to preserve hard-kill fail-closed behavior.
-The Yul identity report script now wraps both internal Solidity IR build and Verity artifact-prep sub-steps with this same timeout wrapper (`MORPHO_SOLIDITY_IR_BUILD_TIMEOUT_SEC`, `MORPHO_VERITY_PREP_TIMEOUT_SEC`) so long sub-step stalls fail closed with stage-specific diagnostics.
+The Yul identity report script wraps both internal Solidity IR build and Verity artifact-prep sub-steps with this same timeout wrapper (`MORPHO_SOLIDITY_IR_BUILD_TIMEOUT_SEC`, `MORPHO_VERITY_PREP_TIMEOUT_SEC`) so long sub-step stalls fail closed with stage-specific diagnostics. When `MORPHO_VERITY_PREPARED_ARTIFACT_DIR` is provided, the report reuses that verified bundle and still fails closed if `Morpho.yul` is missing.
 CI sets stricter non-conflicting outer budgets for nested timeout-wrapped stages:
 - `MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC=3600` with `MORPHO_VERITY_PREP_TIMEOUT_SEC=2400`
 - `MORPHO_YUL_IDENTITY_TIMEOUT_SEC=4200` with `MORPHO_VERITY_PREP_TIMEOUT_SEC=3000`

--- a/docs/RELEASE_CRITERIA.md
+++ b/docs/RELEASE_CRITERIA.md
@@ -13,7 +13,7 @@ Partially enforced:
 4. `unsupported-gap-manifest` drift gate is enforced in CI (`yul-identity-report` with `--enforce-unsupported-manifest`).
 5. `yul-identity-report` emits structural AST diagnostics in CI artifacts.
 6. `macro-migration-blockers` drift gate is enforced in CI (`scripts/check_macro_migration_blockers.py`).
-7. Long differential lane reuses a verified EDSL artifact bundle from `verity-compiled-tests` (reduced duplicate prep/timeout surface).
+7. Long differential and Yul identity lanes reuse a verified EDSL artifact bundle from `verity-compiled-tests` (reduced duplicate prep/timeout surface).
 8. EDSL-only parity naming gate is enforced in CI (`scripts/check_parity_edsl_naming.py`).
 9. Artifact layout boundary gate is enforced in CI (`scripts/check_artifact_layout_boundary.py`).
 

--- a/scripts/check_artifact_layout_boundary.py
+++ b/scripts/check_artifact_layout_boundary.py
@@ -14,6 +14,7 @@ TARGETS = [
   ROOT / "Morpho" / "Compiler" / "MainTest.lean",
   ROOT / "scripts" / "prepare_verity_morpho_artifact.sh",
   ROOT / "scripts" / "run_morpho_blue_parity.sh",
+  ROOT / "scripts" / "report_yul_identity_gap.py",
   ROOT / "scripts" / "test_prepare_verity_morpho_artifact.sh",
   ROOT / "scripts" / "test_run_morpho_blue_parity.sh",
   ROOT / "verity-foundry" / "foundry.toml",


### PR DESCRIPTION
## Summary
This closes a remaining long-lane hardening gap in #39 by making the `yul-identity-report` lane reuse the verified EDSL artifact bundle produced by `verity-compiled-tests`.

### What changed
- `yul-identity-report` now depends on `verity-compiled-tests` and downloads `verity-edsl-artifacts`.
- `scripts/report_yul_identity_gap.py` now:
  - reads Verity Yul from `artifacts/yul/Morpho.yul` (canonical generated path),
  - supports fail-closed reuse via `MORPHO_VERITY_PREPARED_ARTIFACT_DIR`, resolving either `<dir>/edsl` or `<dir>`,
  - fails closed if prepared `Morpho.yul` is missing.
- Added unit coverage for prepared artifact dir resolution and missing-artifact failure.
- Extended artifact layout boundary guard to include `scripts/report_yul_identity_gap.py`.
- Updated README + release criteria wording to reflect Yul identity lane reuse behavior.

## Why this is high leverage
- Removes duplicate Verity artifact preparation from another long lane.
- Shrinks timeout surface area and makes lane behavior consistent with existing parity-lane artifact reuse.
- Preserves fail-closed semantics.

## Validation
- `python3 scripts/test_report_yul_identity_gap.py`
- `python3 scripts/check_artifact_layout_boundary.py`
- `python3 scripts/test_check_artifact_layout_boundary.py`
- `python3 scripts/check_ci_timeout_defaults.py`

Closes #39 (hardening slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI job dependencies/artifact plumbing and the Yul identity report’s input source/path handling; failures would primarily surface as CI breakage or missing-artifact errors rather than runtime/security issues.
> 
> **Overview**
> **Yul identity CI now reuses verified artifacts.** The `yul-identity-report` job depends on `verity-compiled-tests`, downloads the `verity-edsl-artifacts` bundle, and passes `MORPHO_VERITY_PREPARED_ARTIFACT_DIR` so the lane avoids re-preparing Verity outputs.
> 
> **Report script input handling is hardened.** `scripts/report_yul_identity_gap.py` switches the expected Verity Yul path to `artifacts/yul/Morpho.yul`, adds helpers to resolve/copy a prepared artifact directory (preferring `<dir>/edsl`), and fails closed if the prepared `Morpho.yul` is missing; unit tests and docs/gates are updated accordingly (artifact boundary check now includes this script, and README/release criteria reflect the reuse behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abdf5cccc515747e22ab4f025225346d04f81c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->