### PR TITLE
morpho: migrate enableIrm into macro slice

### DIFF
--- a/Morpho/Compiler/MacroSlice.lean
+++ b/Morpho/Compiler/MacroSlice.lean
@@ -50,4 +50,12 @@ verity_contract MorphoViewSlice where
     require (newFeeRecipient != currentFeeRecipient) "already set"
     setStorageAddr feeRecipientSlot newFeeRecipient
 
+  function enableIrm (irm : Address) : Unit := do
+    let sender <- msgSender
+    let currentOwner <- getStorageAddr ownerSlot
+    require (sender == currentOwner) "not owner"
+    let currentValue <- getMapping isIrmEnabledSlot irm
+    require (currentValue == 0) "already set"
+    setMapping isIrmEnabledSlot irm 1
+
 end Morpho.Compiler.MacroSlice

--- a/config/macro-migration-slice.json
+++ b/config/macro-migration-slice.json
@@ -1,6 +1,7 @@
 {
   "contract": "MorphoViewSlice",
   "expectedMigrated": [
+    "enableIrm(address)",
     "feeRecipient()",
     "isAuthorized(address,address)",
     "isIrmEnabled(address)",


### PR DESCRIPTION
## Summary
- migrate `enableIrm(address)` into `MorphoViewSlice` via `verity_contract`
- keep selector-slice baseline fail-closed by updating `config/macro-migration-slice.json`
- this increases macro-slice selector coverage from `7/34` to `8/34`

## Why this slice
- `#38` is the active migration epic and no open PRs were available
- `enableIrm` is owner-gated and selector-stable, and uses already-supported macro primitives (`msgSender`, `getStorageAddr`, `getMapping`, `setMapping`, `require`)

## Validation
- `lake build Morpho.Compiler.MacroSlice Morpho.Compiler.Main Morpho.Compiler.MainTest`
- `python3 scripts/check_macro_migration_slice.py --json-out out/parity-target/macro-migration-slice.json`
- `python3 scripts/test_check_macro_migration_slice.py`
- `python3 scripts/check_macro_migration_surface.py --json-out out/parity-target/macro-migration-surface.json`
- `python3 scripts/check_macro_migration_blockers.py --json-out out/parity-target/macro-migration-blockers.json`

## Notes
- attempted follow-on migration of `isLltvEnabled/enableLltv` and `setAuthorization`, but current macro constraints still block them:
  - `Bool` parameter unsupported in `verity_contract` (`setAuthorization`)
  - `getMappingUint` / `setMappingUint` not accepted as bind sources in macro DSL (`isLltvEnabled`, `enableLltv`)
- this PR keeps the slice strictly buildable and fail-closed while advancing coverage.

Refs #38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new state-mutating selector to the macro-native slice; while owner-gated, it touches on-chain storage/mapping writes and could affect migration parity if the selector or semantics diverge.
> 
> **Overview**
> Migrates `enableIrm(address)` into the macro-native `MorphoViewSlice`, implementing the owner-gated mapping update (`isIrmEnabledSlot[irm] = 1`) with a fail-fast check for already-enabled IRMs.
> 
> Updates `config/macro-migration-slice.json` to include `enableIrm(address)` in the fail-closed `expectedMigrated` baseline so selector coverage tracking stays in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6f75455c4067a16f9e1fa8173c928482f62bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->