### PR TITLE
checker: fail closed on placeholder macro migration blockers

### DIFF
--- a/scripts/check_macro_migration_slice.py
+++ b/scripts/check_macro_migration_slice.py
@@ -135,6 +135,16 @@ def validate_blocked_against_baseline(
       "baseline expectedBlocked contains empty/invalid reason(s): "
       f"{sorted(invalid_reason)}"
     )
+  placeholder_reason = [
+    sig
+    for sig, reason in blocked.items()
+    if isinstance(reason, str) and reason.strip() == "pending macro migration (tracked blocker)"
+  ]
+  if placeholder_reason:
+    raise MigrationSliceError(
+      "baseline expectedBlocked contains placeholder reason(s); use explicit blocker categories: "
+      f"{sorted(placeholder_reason)}"
+    )
 
   expected_blocked = set(blocked)
   actual_blocked = spec_signatures - migrated_signatures

--- a/scripts/test_check_macro_migration_slice.py
+++ b/scripts/test_check_macro_migration_slice.py
@@ -87,6 +87,18 @@ class BaselineValidationTests(unittest.TestCase):
         baseline={"expectedBlocked": {"owner()": "invalid"}},
       )
 
+  def test_validate_blocked_against_baseline_rejects_placeholder_reason(self) -> None:
+    with self.assertRaises(MigrationSliceError):
+      validate_blocked_against_baseline(
+        spec_signatures={"owner()", "nonce(address)"},
+        migrated_signatures={"owner()"},
+        baseline={
+          "expectedBlocked": {
+            "nonce(address)": "pending macro migration (tracked blocker)",
+          }
+        },
+      )
+
 
 class RepoCheckTests(unittest.TestCase):
   def test_current_repo_slice_matches(self) -> None:


### PR DESCRIPTION
## Summary
- reject placeholder blocker reason text (`pending macro migration (tracked blocker)`) in `expectedBlocked`
- require explicit blocker classification for every non-migrated signature
- add regression unit test for placeholder rejection

## Why
Issue #38 tracks a fail-closed migration baseline. Placeholder reasons make the baseline ambiguous and can hide drift in blocker taxonomy. This change forces explicit reasons before baseline updates are accepted.

## Test plan
- `python3 scripts/test_check_macro_migration_slice.py`
- `python3 scripts/check_macro_migration_slice.py --json-out out/parity-target/macro-migration-slice.json`
- `lake build Morpho.Compiler.MacroSlice Morpho.Compiler.Main Morpho.Compiler.MainTest`

Refs #38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens validation in a repo-checking script and adds a unit test; the main impact is that CI/baseline updates may now fail until explicit blocker reasons are provided.
> 
> **Overview**
> Tightens the macro migration slice baseline validator to **fail closed** when any `expectedBlocked` entry uses the placeholder reason `pending macro migration (tracked blocker)`, forcing explicit, non-empty blocker categories for every non-migrated signature.
> 
> Adds a regression unit test to ensure placeholder reasons are rejected during `validate_blocked_against_baseline` validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51d90abc1c84f6a0548e9dc93af0ec5dc73250f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->