### PR TITLE
Harden macro migration slice baseline metadata checks

### DIFF
--- a/scripts/test_check_macro_migration_slice.py
+++ b/scripts/test_check_macro_migration_slice.py
@@ -12,6 +12,7 @@ from check_macro_migration_slice import (  # noqa: E402
   MigrationSliceError,
   ROOT,
   extract_macro_signatures,
+  validate_baseline_metadata,
   run_check,
   validate_blocked_against_baseline,
   validate_against_baseline,
@@ -85,6 +86,38 @@ class BaselineValidationTests(unittest.TestCase):
         spec_signatures={"owner()"},
         migrated_signatures={"owner()"},
         baseline={"expectedBlocked": {"owner()": "invalid"}},
+      )
+
+  def test_validate_baseline_metadata_matches(self) -> None:
+    validate_baseline_metadata(
+      baseline={
+        "contract": "MorphoViewSlice",
+        "source": "Morpho/Compiler/MacroSlice.lean",
+      },
+      macro_path=ROOT / "Morpho" / "Compiler" / "MacroSlice.lean",
+      contract_name="MorphoViewSlice",
+    )
+
+  def test_validate_baseline_metadata_detects_contract_mismatch(self) -> None:
+    with self.assertRaises(MigrationSliceError):
+      validate_baseline_metadata(
+        baseline={
+          "contract": "OtherSlice",
+          "source": "Morpho/Compiler/MacroSlice.lean",
+        },
+        macro_path=ROOT / "Morpho" / "Compiler" / "MacroSlice.lean",
+        contract_name="MorphoViewSlice",
+      )
+
+  def test_validate_baseline_metadata_detects_source_mismatch(self) -> None:
+    with self.assertRaises(MigrationSliceError):
+      validate_baseline_metadata(
+        baseline={
+          "contract": "MorphoViewSlice",
+          "source": "Morpho/Compiler/NotMacroSlice.lean",
+        },
+        macro_path=ROOT / "Morpho" / "Compiler" / "MacroSlice.lean",
+        contract_name="MorphoViewSlice",
       )
 
   def test_validate_blocked_against_baseline_rejects_placeholder_reason(self) -> None:


### PR DESCRIPTION
## Summary
Advances #38 by hardening the fail-closed migration-slice checker against baseline metadata drift.

## Changes
- `scripts/check_macro_migration_slice.py`
  - Added `validate_baseline_metadata`.
  - Enforces baseline `contract` exactly matches `--contract` (default `MorphoViewSlice`).
  - Enforces baseline `source` exactly matches the checked macro source path.
  - Fails closed on missing/empty/mismatched metadata before signature-set validation.
- `scripts/test_check_macro_migration_slice.py`
  - Added regression tests for metadata match, contract mismatch, and source mismatch.

## Why this matters
`expectedMigrated`/`expectedBlocked` set checks are already strict, but a stale or copied baseline file could still point at the wrong contract/source. This guard closes that gap so migration reports remain tied to the intended macro slice artifact.

## Validation
- `python3 scripts/test_check_macro_migration_slice.py`
- `python3 scripts/check_macro_migration_slice.py --json-out out/parity-target/macro-migration-slice.json`
- `lake build Morpho.Compiler.MacroSlice Morpho.Compiler.Main Morpho.Compiler.MainTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds stricter validation to a standalone migration-check script and unit tests, with failures limited to cases where the baseline metadata is missing or mismatched.
> 
> **Overview**
> Adds **fail-closed baseline metadata validation** to `check_macro_migration_slice.py`, requiring the baseline JSON to include non-empty `contract` and `source` fields that exactly match the `--contract` value and the checked macro file path before any signature-set comparisons run.
> 
> Extends `test_check_macro_migration_slice.py` with regression coverage for the new metadata checks (happy path plus contract/source mismatch failures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc1ed41a385cc01907739d65647f113523eb87b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->