### PR TITLE
fix: correct README theorem counts — solvency and collateralization cover 17 ops, not 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The approach: translate Morpho's Solidity logic line-by-line into Verity's contr
 
 ### What this proves
 
-- **Solvency**: total borrows never exceed total supply, preserved by all 16 state-mutating operations (supply, withdraw, borrow, repay, liquidate, accrueInterest, supplyCollateral, withdrawCollateral, createMarket, setFee, and all admin functions)
+- **Solvency**: total borrows never exceed total supply, preserved by all 17 state-mutating operations (supply, withdraw, borrow, repay, liquidate, accrueInterest, accrueInterestPublic, supplyCollateral, withdrawCollateral, createMarket, setFee, and all admin functions)
 - **Rounding safety**: all share/asset conversions round against the user; round-trip supply-withdraw never returns more than deposited
 - **Authorization**: only authorized addresses can withdraw, borrow, or remove collateral; liquidation requires an unhealthy position; signature-based delegation requires valid nonce and unexpired deadline
 - **Fee bounds**: market fees stay within the 25% cap
-- **Collateralization**: positions with debt always have collateral, preserved by all 16 operations including borrow and withdrawCollateral (guarded by health checks; bad debt is socialized by liquidation)
+- **Collateralization**: positions with debt always have collateral, preserved by all 17 operations including borrow and withdrawCollateral (guarded by health checks; bad debt is socialized by liquidation)
 - **Monotonicity**: enabled IRMs/LLTVs cannot be disabled across all operations; market timestamps only increase through accrueInterest, setFee, and accrueInterestPublic
 - **Exchange rate safety**: supply share exchange rate never decreases after interest accrual (accrueInterest and accrueInterestPublic); existing shareholders' per-share value is protected
 - **Market isolation**: operations on one market never affect any other market's state, same-market user positions, or any position in other markets
@@ -296,8 +296,8 @@ Also proven in supporting libraries:
 - `u256_val` — simp lemma for Uint256 wrapping arithmetic
 
 Invariant theorems (105) include:
-- Solvency (borrowLeSupply) preserved by all 16 operations + accrueInterestPublic (17 public + 3 helper lemmas)
-- Collateralization preserved by all 16 operations (16 public + 3 helper lemmas)
+- Solvency (borrowLeSupply) preserved by all 17 operations (17 public + 3 helper lemmas)
+- Collateralization preserved by all 17 operations (17 public + 3 helper lemmas)
 - IRM monotonicity preserved by 14 operations including accrueInterestPublic (14)
 - LLTV monotonicity preserved by 14 operations including accrueInterestPublic (14)
 - Market isolation for 8 operations: accrueInterest/supply/withdraw/borrow/repay/liquidate/supplyCollateral/withdrawCollateral (8)
@@ -336,7 +336,7 @@ Share consistency theorems (36) include:
 - [x] Math libraries (MathLib, SharesMathLib, UtilsLib, ConstantsLib)
 - [x] Formal specs with human-readable documentation (invariants, rounding, authorization)
 - [x] Authorization proofs (13: withdraw/borrow/withdrawCollateral require auth, supply doesn't, postcondition specs, liquidation requires unhealthy, signature validation, helper lemmas)
-- [x] Invariant proofs (105: solvency × 17, collateralization × 16, IRM/LLTV monotonicity × 14 each, market/position isolation × 24, timestamp × 3, exchange rate × 2, standalone checks, helper lemmas)
+- [x] Invariant proofs (105: solvency × 17, collateralization × 17, IRM/LLTV monotonicity × 14 each, market/position isolation × 24, timestamp × 3, exchange rate × 2, standalone checks, helper lemmas)
 - [x] Rounding proofs (4/4: toSharesDown ≤ toSharesUp, toAssetsDown ≤ toAssetsUp, supply round-trip protocol-safe, withdraw round-trip protocol-safe)
 - [x] Share consistency proofs (36: supplySharesConsistent and borrowSharesConsistent preserved by all 17 operations including liquidate bad-debt socialization, helper lemmas)
 - [x] Solidity equivalence bridge proofs (67: borrowLeSupply/alwaysCollateralized preserved across 17 operations, irmMonotone/lltvMonotone across 16, flashLoan zero-asset rejection)


### PR DESCRIPTION
## Summary
- Fixes 5 occurrences where the README claims solvency/collateralization are "preserved by all 16 operations" — the actual proven count is **17** (includes `accrueInterestPublic`)

## Evidence
Lean proofs that the README was undercounting:
- `accrueInterestPublic_preserves_borrowLeSupply` — `Invariants.lean:1101`
- `accrueInterestPublic_preserves_alwaysCollateralized` — `Invariants.lean:1115`
- `solidity_accrueInterestPublic_preserves_borrowLeSupply` — `SolidityBridge.lean:958`
- `solidity_accrueInterestPublic_preserves_alwaysCollateralized` — `SolidityBridge.lean:974`

Total theorem counts verified via grep:
- `*_preserves_borrowLeSupply`: 17 public theorems ✓
- `*_preserves_alwaysCollateralized`: 17 public theorems ✓
- `solidity_*_preserves_borrowLeSupply`: 17 bridge theorems ✓
- `solidity_*_preserves_alwaysCollateralized`: 17 bridge theorems ✓

The share-accounting line (line 21) already correctly listed all 17 operations.

## Changes
| Line | Before | After |
|------|--------|-------|
| 13 (solvency headline) | "all 16 state-mutating operations" | "all 17 state-mutating operations" + added `accrueInterestPublic` |
| 17 (collateralization headline) | "all 16 operations" | "all 17 operations" |
| 299 (invariant breakdown) | "all 16 operations + accrueInterestPublic" | "all 17 operations" |
| 300 (collat breakdown) | "all 16 operations (16 public" | "all 17 operations (17 public" |
| 339 (status checklist) | "collateralization × 16" | "collateralization × 17" |

## Test plan
- [x] All CI validation scripts pass locally
- [x] Counts verified against actual Lean theorem declarations
- [ ] CI critical gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that correct theorem/operation counts and wording; no code, proofs, or behavior are modified.
> 
> **Overview**
> Updates `README.md` to consistently state that **solvency** and **collateralization** invariants are preserved across **17** state-mutating operations (explicitly including `accrueInterestPublic`), correcting multiple spots that previously said 16.
> 
> Adjusts the invariant-theorem breakdown and status checklist to match the 17-operation counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0f6c52483a76e8137e6aaa024649fbce0eb93f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->