### PR TITLE
test: skip integration checks when submodule fixtures are absent

### DIFF
--- a/scripts/test_check_macro_migration_surface.py
+++ b/scripts/test_check_macro_migration_surface.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 import sys
 import unittest
 
@@ -67,6 +68,9 @@ def morphoSelectors : List Nat := [
     self.assertEqual(entries[0], ("DOMAIN_SEPARATOR()", 0x3644E515))
     self.assertEqual(entries[1], ("owner()", 0x8DA5CB5B))
 
+  @unittest.skipUnless((ROOT / "morpho-blue" / "src" / "interfaces" / "IMorpho.sol").exists(),
+                       "requires initialized morpho-blue submodule (IMorpho.sol)")
+  @unittest.skipUnless(shutil.which("solc"), "requires solc on PATH")
   def test_current_repo_surface_matches(self) -> None:
     report = run_check()
     self.assertEqual(report["status"], "ok")

--- a/scripts/test_check_morpho_selectors_sync.py
+++ b/scripts/test_check_morpho_selectors_sync.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 import sys
 import unittest
 
@@ -64,6 +65,9 @@ def morphoSelectors : List Nat := [
     self.assertTrue(unchanged)
     self.assertEqual(rewritten, first)
 
+  @unittest.skipUnless((pathlib.Path(__file__).resolve().parent.parent / "morpho-blue" / "src" / "interfaces" / "IMorpho.sol").exists(),
+                       "requires initialized morpho-blue submodule (IMorpho.sol)")
+  @unittest.skipUnless(shutil.which("solc"), "requires solc on PATH")
   def test_repo_selector_migration_surface_still_ok(self) -> None:
     # Integration smoke check tied to repository sources.
     report = run_check()


### PR DESCRIPTION
## Summary
- add prerequisite guards to integration-style unit tests that rely on `morpho-blue/src/interfaces/IMorpho.sol`
- also guard those tests on `solc` availability
- keep parser/unit logic tests always-on, but skip repo-fixture integration checks in environments that do not have submodules initialized

## Why
Running `python3 -m unittest discover -s scripts -p 'test_*.py'` in a fresh/local clone without submodules currently fails with `FileNotFoundError` for `IMorpho.sol`. CI uses recursive submodules so this mostly affects local contributors and automation environments.

## Validation
- `python3 -m unittest discover -s scripts -p 'test_*.py'` (passes; two integration checks are skipped when prerequisites are absent)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes unit test execution conditions by skipping integration-style checks when prerequisites are missing; no production logic changes.
> 
> **Overview**
> Adds prerequisite guards to the two integration-style tests that call `run_check()` so they’re skipped unless `morpho-blue/src/interfaces/IMorpho.sol` exists and `solc` is on `PATH`.
> 
> All pure parser/unit tests remain always-on; this prevents local/CI failures in environments without initialized submodules or Solidity tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f29565bf938fd33ad4d098bcbba3b98e15494f6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->