### PR TITLE
Add fail-closed CI guard for script test coverage

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Validate CI timeout defaults sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI timeout defaults sync" -- python3 scripts/check_ci_timeout_defaults.py
 
+      - name: Validate CI script-test coverage sync
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI script-test coverage sync" -- python3 scripts/check_ci_test_coverage.py
+
       - name: Validate parity EDSL-only naming
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate parity EDSL-only naming" -- python3 scripts/check_parity_edsl_naming.py
 
@@ -150,6 +153,9 @@ jobs:
 
       - name: Run CI timeout defaults unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI timeout defaults unit tests" -- python3 scripts/test_check_ci_timeout_defaults.py
+
+      - name: Run CI script-test coverage unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI script-test coverage unit tests" -- python3 scripts/test_check_ci_test_coverage.py
 
       - name: Run parity EDSL-only naming unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity EDSL-only naming unit tests" -- python3 scripts/test_check_parity_edsl_naming.py

--- a/scripts/check_ci_test_coverage.py
+++ b/scripts/check_ci_test_coverage.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Fail-closed sync check for script unit tests vs workflow references."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+WORKFLOW_TEST_REF_RE = re.compile(r"\bscripts/(test_[A-Za-z0-9_]+\.(?:py|sh))\b")
+
+
+def fail(msg: str) -> None:
+  print(f"ci-test-coverage check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_repo_script_tests(scripts_dir: pathlib.Path) -> set[str]:
+  tests: set[str] = set()
+  for path in scripts_dir.glob("test_*.py"):
+    if path.is_file():
+      tests.add(path.name)
+  for path in scripts_dir.glob("test_*.sh"):
+    if path.is_file():
+      tests.add(path.name)
+  return tests
+
+
+def collect_workflow_script_tests(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in WORKFLOW_TEST_REF_RE.finditer(workflow_text)}
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate script unit tests remain covered by verify workflow"
+  )
+  parser.add_argument(
+    "--workflow",
+    type=pathlib.Path,
+    default=pathlib.Path(".github/workflows/verify.yml"),
+    help="Path to workflow yaml",
+  )
+  parser.add_argument(
+    "--scripts-dir",
+    type=pathlib.Path,
+    default=pathlib.Path("scripts"),
+    help="Path to scripts directory",
+  )
+  args = parser.parse_args()
+
+  workflow_text = args.workflow.read_text(encoding="utf-8")
+  repo_tests = collect_repo_script_tests(args.scripts_dir)
+  workflow_tests = collect_workflow_script_tests(workflow_text)
+
+  missing_from_workflow = sorted(repo_tests - workflow_tests)
+  if missing_from_workflow:
+    fail("repo script tests missing from workflow: " + ", ".join(missing_from_workflow))
+
+  stale_workflow_refs = sorted(workflow_tests - repo_tests)
+  if stale_workflow_refs:
+    fail("workflow references missing script tests: " + ", ".join(stale_workflow_refs))
+
+  print(
+    "ci-test-coverage: "
+    f"repo_tests={len(repo_tests)} workflow_tests={len(workflow_tests)}"
+  )
+  print("ci-test-coverage check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_ci_test_coverage.py
+++ b/scripts/test_check_ci_test_coverage.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Unit tests for CI script-test coverage sync check."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_ci_test_coverage import (  # noqa: E402
+  collect_repo_script_tests,
+  collect_workflow_script_tests,
+  main,
+)
+
+
+class CheckCiTestCoverageTests(unittest.TestCase):
+  def test_collect_repo_script_tests(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
+      (scripts_dir / "test_gamma.txt").write_text("", encoding="utf-8")
+      self.assertEqual(collect_repo_script_tests(scripts_dir), {"test_alpha.py", "test_beta.sh"})
+
+  def test_collect_workflow_script_tests(self) -> None:
+    workflow = (
+      "run: python3 scripts/test_alpha.py\n"
+      "run: ./scripts/test_beta.sh\n"
+      "run: python3 scripts/check_something.py\n"
+    )
+    self.assertEqual(collect_workflow_script_tests(workflow), {"test_alpha.py", "test_beta.sh"})
+
+  def test_main_passes_when_repo_and_workflow_match(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 scripts/test_alpha.py\n"
+        "run: ./scripts/test_beta.sh\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_test_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_repo_test_missing_from_workflow(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
+      workflow.write_text("run: python3 scripts/test_alpha.py\n", encoding="utf-8")
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_test_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_workflow_has_stale_reference(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 scripts/test_alpha.py\n"
+        "run: ./scripts/test_beta.sh\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_test_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/check_ci_test_coverage.py` to fail-closed on drift between tracked `scripts/test_*` files and workflow references
- add `scripts/test_check_ci_test_coverage.py` unit coverage for the checker
- wire checker + unit tests into `.github/workflows/verify.yml` parity-target validation/test lanes

## Why
Script tests are manually enumerated in workflow steps. This guard prevents silent CI coverage regressions when new test files are added or old ones are removed/renamed.

## Validation
- `python3 scripts/check_ci_test_coverage.py`
- `python3 scripts/test_check_ci_test_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new fail-closed CI gate that can block merges if the workflow’s script-test list drifts from the repo, so regex/enum edge cases could cause unexpected CI failures.
> 
> **Overview**
> Adds a new `scripts/check_ci_test_coverage.py` validation that compares tracked `scripts/test_*.py`/`test_*.sh` files against `scripts/test_*` references in `.github/workflows/verify.yml`, failing if any tests are missing or if the workflow references stale tests.
> 
> Wires this checker and its new unit suite (`scripts/test_check_ci_test_coverage.py`) into the `parity-target` validate/test lanes in `verify.yml` to prevent silent drift in CI script-test coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f2ed8cfcc157e518c3f32a3cf239dfe4ef77cda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->