### PR TITLE
Add fail-closed CI coverage guard for check scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Validate CI script-test coverage sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI script-test coverage sync" -- python3 scripts/check_ci_test_coverage.py
 
+      - name: Validate CI check-script coverage sync
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI check-script coverage sync" -- python3 scripts/check_ci_check_coverage.py
+
       - name: Validate parity EDSL-only naming
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate parity EDSL-only naming" -- python3 scripts/check_parity_edsl_naming.py
 
@@ -156,6 +159,9 @@ jobs:
 
       - name: Run CI script-test coverage unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI script-test coverage unit tests" -- python3 scripts/test_check_ci_test_coverage.py
+
+      - name: Run CI check-script coverage unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI check-script coverage unit tests" -- python3 scripts/test_check_ci_check_coverage.py
 
       - name: Run parity EDSL-only naming unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity EDSL-only naming unit tests" -- python3 scripts/test_check_parity_edsl_naming.py

--- a/scripts/check_ci_check_coverage.py
+++ b/scripts/check_ci_check_coverage.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Fail-closed sync check for check scripts vs workflow references."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.py)\b")
+
+
+def fail(msg: str) -> None:
+  print(f"ci-check-coverage check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_repo_check_scripts(scripts_dir: pathlib.Path) -> set[str]:
+  checks: set[str] = set()
+  for path in scripts_dir.glob("check_*.py"):
+    if path.is_file():
+      checks.add(path.name)
+  return checks
+
+
+def collect_workflow_check_scripts(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(workflow_text)}
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate check scripts remain covered by verify workflow"
+  )
+  parser.add_argument(
+    "--workflow",
+    type=pathlib.Path,
+    default=pathlib.Path(".github/workflows/verify.yml"),
+    help="Path to workflow yaml",
+  )
+  parser.add_argument(
+    "--scripts-dir",
+    type=pathlib.Path,
+    default=pathlib.Path("scripts"),
+    help="Path to scripts directory",
+  )
+  args = parser.parse_args()
+
+  workflow_text = args.workflow.read_text(encoding="utf-8")
+  repo_checks = collect_repo_check_scripts(args.scripts_dir)
+  workflow_checks = collect_workflow_check_scripts(workflow_text)
+
+  missing_from_workflow = sorted(repo_checks - workflow_checks)
+  if missing_from_workflow:
+    fail("repo check scripts missing from workflow: " + ", ".join(missing_from_workflow))
+
+  stale_workflow_refs = sorted(workflow_checks - repo_checks)
+  if stale_workflow_refs:
+    fail("workflow references missing check scripts: " + ", ".join(stale_workflow_refs))
+
+  print(
+    "ci-check-coverage: "
+    f"repo_checks={len(repo_checks)} workflow_checks={len(workflow_checks)}"
+  )
+  print("ci-check-coverage check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_ci_check_coverage.py
+++ b/scripts/test_check_ci_check_coverage.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Unit tests for CI check-script coverage sync check."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_ci_check_coverage import (  # noqa: E402
+  collect_repo_check_scripts,
+  collect_workflow_check_scripts,
+  main,
+)
+
+
+class CheckCiCheckCoverageTests(unittest.TestCase):
+  def test_collect_repo_check_scripts(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "check_beta.sh").write_text("", encoding="utf-8")
+      self.assertEqual(collect_repo_check_scripts(scripts_dir), {"check_alpha.py"})
+
+  def test_collect_workflow_check_scripts(self) -> None:
+    workflow = (
+      "run: python3 scripts/check_alpha.py\n"
+      "run: python3 scripts/test_alpha.py\n"
+    )
+    self.assertEqual(collect_workflow_check_scripts(workflow), {"check_alpha.py"})
+
+  def test_main_passes_when_repo_and_workflow_match(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "check_beta.py").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 scripts/check_alpha.py\n"
+        "run: python3 scripts/check_beta.py\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_check_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_repo_check_missing_from_workflow(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "check_beta.py").write_text("", encoding="utf-8")
+      workflow.write_text("run: python3 scripts/check_alpha.py\n", encoding="utf-8")
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_check_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_workflow_has_stale_reference(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 scripts/check_alpha.py\n"
+        "run: python3 scripts/check_beta.py\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_check_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/check_ci_check_coverage.py` to fail closed on workflow drift for `scripts/check_*.py`
- add unit coverage in `scripts/test_check_ci_check_coverage.py`
- wire both checker and unit tests into `.github/workflows/verify.yml`

## Validation
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/test_check_ci_check_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #87

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new CI gate that can fail builds if the workflow parsing/regex misses valid references or if future workflow edits aren’t kept in sync.
> 
> **Overview**
> **Adds a new CI “coverage” validation for check scripts.** A new `scripts/check_ci_check_coverage.py` compares repo `scripts/check_*.py` files against `scripts/check_*.py` references in `.github/workflows/verify.yml`, failing if any are missing or stale.
> 
> The PR also adds `scripts/test_check_ci_check_coverage.py` unit tests for the new checker and wires both the checker and its tests into the `verify.yml` `parity-target` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb4cbabed57e42334c02440e84945283da64e386. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->