### PR TITLE
Add fail-closed script-to-test pairing guard

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Validate CI check-script coverage sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI check-script coverage sync" -- python3 scripts/check_ci_check_coverage.py
 
+      - name: Validate script-test pairing
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate script-test pairing" -- python3 scripts/check_script_test_pairs.py
+
       - name: Validate parity EDSL-only naming
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate parity EDSL-only naming" -- python3 scripts/check_parity_edsl_naming.py
 
@@ -162,6 +165,9 @@ jobs:
 
       - name: Run CI check-script coverage unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI check-script coverage unit tests" -- python3 scripts/test_check_ci_check_coverage.py
+
+      - name: Run script-test pairing unit tests
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Script-test pairing unit tests" -- python3 scripts/test_check_script_test_pairs.py
 
       - name: Run parity EDSL-only naming unit tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity EDSL-only naming unit tests" -- python3 scripts/test_check_parity_edsl_naming.py

--- a/scripts/check_script_test_pairs.py
+++ b/scripts/check_script_test_pairs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail-closed check that every operational script has a matching unit test."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def fail(msg: str) -> None:
+  print(f"script-test-pairs check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_repo_scripts(scripts_dir: pathlib.Path) -> set[str]:
+  scripts: set[str] = set()
+  for path in scripts_dir.glob("*"):
+    if not path.is_file():
+      continue
+    if path.suffix not in (".py", ".sh"):
+      continue
+    if path.name.startswith("test_"):
+      continue
+    scripts.add(path.name)
+  return scripts
+
+
+def collect_repo_script_tests(scripts_dir: pathlib.Path) -> set[str]:
+  tests: set[str] = set()
+  for path in scripts_dir.glob("test_*"):
+    if path.is_file() and path.suffix in (".py", ".sh"):
+      tests.add(path.name)
+  return tests
+
+
+def expected_tests_for_script(script_name: str) -> set[str]:
+  stem = pathlib.Path(script_name).stem
+  return {f"test_{stem}.py", f"test_{stem}.sh"}
+
+
+def source_candidates_for_test(test_name: str) -> set[str]:
+  if not test_name.startswith("test_"):
+    return set()
+  stem = pathlib.Path(test_name).stem
+  source_stem = stem[len("test_") :]
+  return {f"{source_stem}.py", f"{source_stem}.sh"}
+
+
+def find_missing_tests(repo_scripts: set[str], repo_tests: set[str]) -> list[str]:
+  missing: list[str] = []
+  for script_name in sorted(repo_scripts):
+    if expected_tests_for_script(script_name).isdisjoint(repo_tests):
+      missing.append(script_name)
+  return missing
+
+
+def find_stale_tests(repo_scripts: set[str], repo_tests: set[str]) -> list[str]:
+  stale: list[str] = []
+  for test_name in sorted(repo_tests):
+    if source_candidates_for_test(test_name).isdisjoint(repo_scripts):
+      stale.append(test_name)
+  return stale
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate every script has a paired script unit test and vice versa"
+  )
+  parser.add_argument(
+    "--scripts-dir",
+    type=pathlib.Path,
+    default=pathlib.Path("scripts"),
+    help="Path to scripts directory",
+  )
+  args = parser.parse_args()
+
+  repo_scripts = collect_repo_scripts(args.scripts_dir)
+  repo_tests = collect_repo_script_tests(args.scripts_dir)
+
+  missing_tests = find_missing_tests(repo_scripts, repo_tests)
+  if missing_tests:
+    fail("scripts missing matching tests: " + ", ".join(missing_tests))
+
+  stale_tests = find_stale_tests(repo_scripts, repo_tests)
+  if stale_tests:
+    fail("tests missing matching scripts: " + ", ".join(stale_tests))
+
+  print(
+    "script-test-pairs: "
+    f"scripts={len(repo_scripts)} tests={len(repo_tests)}"
+  )
+  print("script-test-pairs check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_script_test_pairs.py
+++ b/scripts/test_check_script_test_pairs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Unit tests for script-to-test pairing guard."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_script_test_pairs import (  # noqa: E402
+  collect_repo_scripts,
+  collect_repo_script_tests,
+  find_missing_tests,
+  find_stale_tests,
+  main,
+)
+
+
+class CheckScriptTestPairsTests(unittest.TestCase):
+  def test_collect_repo_scripts(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "beta.sh").write_text("", encoding="utf-8")
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "notes.txt").write_text("", encoding="utf-8")
+      self.assertEqual(collect_repo_scripts(scripts_dir), {"alpha.py", "beta.sh"})
+
+  def test_collect_repo_script_tests(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
+      (scripts_dir / "alpha.py").write_text("", encoding="utf-8")
+      self.assertEqual(collect_repo_script_tests(scripts_dir), {"test_alpha.py", "test_beta.sh"})
+
+  def test_find_missing_tests(self) -> None:
+    repo_scripts = {"alpha.py", "beta.sh"}
+    repo_tests = {"test_alpha.py"}
+    self.assertEqual(find_missing_tests(repo_scripts, repo_tests), ["beta.sh"])
+
+  def test_find_stale_tests(self) -> None:
+    repo_scripts = {"alpha.py"}
+    repo_tests = {"test_alpha.py", "test_beta.py"}
+    self.assertEqual(find_stale_tests(repo_scripts, repo_tests), ["test_beta.py"])
+
+  def test_main_passes_when_pairs_match(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "beta.sh").write_text("", encoding="utf-8")
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_script_test_pairs.py",
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_script_missing_test(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "alpha.py").write_text("", encoding="utf-8")
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_script_test_pairs.py",
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_stale_test_exists(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.py").write_text("", encoding="utf-8")
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_script_test_pairs.py",
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/check_script_test_pairs.py` to fail closed when `scripts/` gains an unpaired operational script or stale test file
- add `scripts/test_check_script_test_pairs.py` unit coverage for collector + matching logic + failure modes
- wire both scripts into `.github/workflows/verify.yml`

## Why
We already enforce CI references for check scripts and test scripts, but we did not enforce that every operational script has a dedicated unit test counterpart. This closes that reliability gap and prevents untested automation drift.

## Validation
- `python3 scripts/check_script_test_pairs.py`
- `python3 scripts/test_check_script_test_pairs.py`
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/check_ci_test_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #89
