### PR TITLE
CI: discover script tests while preserving fail-closed coverage

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -139,78 +139,15 @@ jobs:
       - name: Run parity-target parser regression tests
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity-target parser regression tests" -- python3 scripts/test_check_parity_target.py
 
-      - name: Run Yul identity report unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Yul identity report unit tests" -- python3 scripts/test_report_yul_identity_gap.py
+      - name: Run Python script unit tests (discovery)
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Python script unit tests (discovery)" -- python3 -m unittest discover -s scripts -p 'test_*.py'
 
-      - name: Run macro migration selector-surface unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Macro migration selector-surface unit tests" -- python3 scripts/test_check_macro_migration_surface.py
-
-      - name: Run morpho selector sync unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Morpho selector sync unit tests" -- python3 scripts/test_check_morpho_selectors_sync.py
-
-      - name: Run macro migration blockers unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Macro migration blockers unit tests" -- python3 scripts/test_check_macro_migration_blockers.py
-
-      - name: Run macro migration selector-slice unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Macro migration selector-slice unit tests" -- python3 scripts/test_check_macro_migration_slice.py
-
-      - name: Run morpho generated boundary unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Morpho generated boundary unit tests" -- python3 scripts/test_check_morpho_generated_boundary.py
-
-      - name: Run CI timeout defaults unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI timeout defaults unit tests" -- python3 scripts/test_check_ci_timeout_defaults.py
-
-      - name: Run CI script-test coverage unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI script-test coverage unit tests" -- python3 scripts/test_check_ci_test_coverage.py
-
-      - name: Run CI check-script coverage unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "CI check-script coverage unit tests" -- python3 scripts/test_check_ci_check_coverage.py
-
-      - name: Run script-test pairing unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Script-test pairing unit tests" -- python3 scripts/test_check_script_test_pairs.py
-
-      - name: Run parity EDSL-only naming unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Parity EDSL-only naming unit tests" -- python3 scripts/test_check_parity_edsl_naming.py
-
-      - name: Run artifact layout boundary unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact layout boundary unit tests" -- python3 scripts/test_check_artifact_layout_boundary.py
-
-      - name: Run semantic bridge obligation unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Semantic bridge obligation unit tests" -- python3 scripts/test_check_semantic_bridge_obligations.py
-
-      - name: Run spec correspondence unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Spec correspondence unit tests" -- python3 scripts/test_check_spec_correspondence.py
-
-      - name: Run primitive coverage unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Primitive coverage unit tests" -- python3 scripts/test_check_primitive_coverage.py
-
-      - name: Run keccak selector helper forwarder unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Keccak selector helper forwarder unit tests" -- python3 scripts/test_keccak256.py
-
-      - name: Run artifact-gate script unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact-gate script unit tests" -- ./scripts/test_check_input_mode_parity.sh
-
-      - name: Run artifact-prep script unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Artifact-prep script unit tests" -- ./scripts/test_prepare_verity_morpho_artifact.sh
-
-      - name: Run Morpho Blue parity script unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Morpho Blue parity script unit tests" -- ./scripts/test_run_morpho_blue_parity.sh
-
-      - name: Run Foundry installer unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Foundry installer unit tests" -- ./scripts/test_install_foundry.sh
-      - name: Run toolchain readiness unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Toolchain readiness unit tests" -- ./scripts/test_check_toolchain_readiness.sh
-
-      - name: Run Lean installer unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Lean installer unit tests" -- ./scripts/test_install_lean.sh
-
-      - name: Run solc installer unit tests
-        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "solc installer unit tests" -- ./scripts/test_install_solc.sh
-
-      - name: Run timeout wrapper unit tests
-        env:
-          MORPHO_TIMEOUT_KILL_AFTER_SEC: "1"
-        run: ./scripts/run_with_timeout.sh MORPHO_TIMEOUT_WRAPPER_TEST_TIMEOUT_SEC 180 "Timeout wrapper unit tests" -- ./scripts/test_run_with_timeout.sh
+      - name: Run shell script unit tests (glob)
+        run: |
+          set -euo pipefail
+          for t in scripts/test_*.sh; do
+            ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_TEST_TIMEOUT_SEC 900 "Shell script unit test: ${t}" -- "./${t}"
+          done
 
   yul-identity-report:
     name: Yul identity gap report (Solidity vs Verity)

--- a/scripts/check_ci_test_coverage.py
+++ b/scripts/check_ci_test_coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed sync check for script unit tests vs workflow references."""
+"""Fail-closed sync check for script unit tests vs workflow coverage."""
 
 from __future__ import annotations
 
@@ -9,6 +9,10 @@ import re
 import sys
 
 WORKFLOW_TEST_REF_RE = re.compile(r"\bscripts/(test_[A-Za-z0-9_]+\.(?:py|sh))\b")
+WORKFLOW_PY_DISCOVER_RE = re.compile(
+  r"python3\s+-m\s+unittest\s+discover[^\n]*-s\s+scripts[^\n]*-p\s+['\"]test_\*\.py['\"]"
+)
+WORKFLOW_SH_GLOB_RE = re.compile(r"\bscripts/test_\*\.sh\b")
 
 
 def fail(msg: str) -> None:
@@ -17,10 +21,19 @@ def fail(msg: str) -> None:
 
 
 def collect_repo_script_tests(scripts_dir: pathlib.Path) -> set[str]:
+  return collect_repo_python_script_tests(scripts_dir) | collect_repo_shell_script_tests(scripts_dir)
+
+
+def collect_repo_python_script_tests(scripts_dir: pathlib.Path) -> set[str]:
   tests: set[str] = set()
   for path in scripts_dir.glob("test_*.py"):
     if path.is_file():
       tests.add(path.name)
+  return tests
+
+
+def collect_repo_shell_script_tests(scripts_dir: pathlib.Path) -> set[str]:
+  tests: set[str] = set()
   for path in scripts_dir.glob("test_*.sh"):
     if path.is_file():
       tests.add(path.name)
@@ -29,6 +42,14 @@ def collect_repo_script_tests(scripts_dir: pathlib.Path) -> set[str]:
 
 def collect_workflow_script_tests(workflow_text: str) -> set[str]:
   return {match.group(1) for match in WORKFLOW_TEST_REF_RE.finditer(workflow_text)}
+
+
+def has_workflow_python_discovery(workflow_text: str) -> bool:
+  return bool(WORKFLOW_PY_DISCOVER_RE.search(workflow_text))
+
+
+def has_workflow_shell_glob(workflow_text: str) -> bool:
+  return bool(WORKFLOW_SH_GLOB_RE.search(workflow_text))
 
 
 def main() -> int:
@@ -50,14 +71,22 @@ def main() -> int:
   args = parser.parse_args()
 
   workflow_text = args.workflow.read_text(encoding="utf-8")
-  repo_tests = collect_repo_script_tests(args.scripts_dir)
-  workflow_tests = collect_workflow_script_tests(workflow_text)
+  repo_py_tests = collect_repo_python_script_tests(args.scripts_dir)
+  repo_sh_tests = collect_repo_shell_script_tests(args.scripts_dir)
+  repo_tests = repo_py_tests | repo_sh_tests
+  workflow_explicit_tests = collect_workflow_script_tests(workflow_text)
+
+  workflow_tests = set(workflow_explicit_tests)
+  if has_workflow_python_discovery(workflow_text):
+    workflow_tests.update(repo_py_tests)
+  if has_workflow_shell_glob(workflow_text):
+    workflow_tests.update(repo_sh_tests)
 
   missing_from_workflow = sorted(repo_tests - workflow_tests)
   if missing_from_workflow:
     fail("repo script tests missing from workflow: " + ", ".join(missing_from_workflow))
 
-  stale_workflow_refs = sorted(workflow_tests - repo_tests)
+  stale_workflow_refs = sorted(workflow_explicit_tests - repo_tests)
   if stale_workflow_refs:
     fail("workflow references missing script tests: " + ", ".join(stale_workflow_refs))
 

--- a/scripts/test_check_ci_test_coverage.py
+++ b/scripts/test_check_ci_test_coverage.py
@@ -14,8 +14,12 @@ if str(SCRIPT_DIR) not in sys.path:
   sys.path.insert(0, str(SCRIPT_DIR))
 
 from check_ci_test_coverage import (  # noqa: E402
+  collect_repo_python_script_tests,
   collect_repo_script_tests,
+  collect_repo_shell_script_tests,
   collect_workflow_script_tests,
+  has_workflow_python_discovery,
+  has_workflow_shell_glob,
   main,
 )
 
@@ -29,6 +33,8 @@ class CheckCiTestCoverageTests(unittest.TestCase):
       (scripts_dir / "test_beta.sh").write_text("", encoding="utf-8")
       (scripts_dir / "test_gamma.txt").write_text("", encoding="utf-8")
       self.assertEqual(collect_repo_script_tests(scripts_dir), {"test_alpha.py", "test_beta.sh"})
+      self.assertEqual(collect_repo_python_script_tests(scripts_dir), {"test_alpha.py"})
+      self.assertEqual(collect_repo_shell_script_tests(scripts_dir), {"test_beta.sh"})
 
   def test_collect_workflow_script_tests(self) -> None:
     workflow = (
@@ -37,6 +43,14 @@ class CheckCiTestCoverageTests(unittest.TestCase):
       "run: python3 scripts/check_something.py\n"
     )
     self.assertEqual(collect_workflow_script_tests(workflow), {"test_alpha.py", "test_beta.sh"})
+
+  def test_detection_of_discovery_modes(self) -> None:
+    workflow = (
+      "run: python3 -m unittest discover -s scripts -p 'test_*.py'\n"
+      "run: for t in scripts/test_*.sh; do echo \"$t\"; done\n"
+    )
+    self.assertTrue(has_workflow_python_discovery(workflow))
+    self.assertTrue(has_workflow_shell_glob(workflow))
 
   def test_main_passes_when_repo_and_workflow_match(self) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -100,6 +114,62 @@ class CheckCiTestCoverageTests(unittest.TestCase):
       workflow.write_text(
         "run: python3 scripts/test_alpha.py\n"
         "run: ./scripts/test_beta.sh\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_test_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_passes_with_discovery_and_glob_coverage(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_beta.py").write_text("", encoding="utf-8")
+      (scripts_dir / "test_gamma.sh").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 -m unittest discover -s scripts -p 'test_*.py'\n"
+        "run: for t in scripts/test_*.sh; do echo \"$t\"; done\n",
+        encoding="utf-8",
+      )
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_test_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_on_stale_explicit_ref_even_with_discovery(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.py").write_text("", encoding="utf-8")
+      workflow.write_text(
+        "run: python3 -m unittest discover -s scripts -p 'test_*.py'\n"
+        "run: python3 scripts/test_stale.py\n",
         encoding="utf-8",
       )
 


### PR DESCRIPTION
## Summary
- replace long manual script-test listing in `verify.yml` with discovery/glob execution
- keep fail-closed guarantees by extending `check_ci_test_coverage.py` to understand coverage via discovery patterns
- add unit coverage for the new detection and stale-reference behavior

## Why
The workflow had high maintenance overhead and drift risk from manually enumerating many `scripts/test_*` entries. This keeps coverage strict while simplifying CI operations.

## Validation
- `python3 scripts/check_ci_test_coverage.py`
- `python3 scripts/test_check_ci_test_coverage.py`
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/check_script_test_pairs.py`
- `python3 scripts/check_ci_timeout_defaults.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `for t in scripts/test_*.sh; do "$t"; done`

Closes #91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how CI discovers and executes tests; mistakes in the discovery/glob detection or patterns could silently skip tests or cause unexpected CI failures.
> 
> **Overview**
> **CI script test execution is simplified** by replacing the long, manually enumerated list of `scripts/test_*` steps in `verify.yml` with `python3 -m unittest discover -s scripts -p 'test_*.py'` plus a `scripts/test_*.sh` glob loop.
> 
> **Fail-closed coverage guarantees are preserved** by updating `scripts/check_ci_test_coverage.py` to treat discovery/glob patterns as covering all matching repo tests while still failing on stale *explicit* workflow references, with new/expanded unit tests in `scripts/test_check_ci_test_coverage.py` to validate the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb0be44e7dab505093cb09a3f95d943bee582e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->