### PR TITLE
ci: enforce timeout-wrapper coverage for check scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Validate CI check-script coverage sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI check-script coverage sync" -- python3 scripts/check_ci_check_coverage.py
 
+      - name: Validate CI timeout-wrapper coverage sync
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI timeout-wrapper coverage sync" -- python3 scripts/check_ci_timeout_wrapper_coverage.py
+
       - name: Validate script-test pairing
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate script-test pairing" -- python3 scripts/check_script_test_pairs.py
 

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Fail-closed check that CI check scripts run under the timeout wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.py)\b")
+RUN_WITH_TIMEOUT_STEP_RE = re.compile(
+  r"run_with_timeout\.sh[^\n]*\s(?:--\s+)?python3\s+scripts/(check_[A-Za-z0-9_]+\.py)\b"
+)
+
+
+def fail(msg: str) -> None:
+  print(f"ci-timeout-wrapper-coverage check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_workflow_check_scripts(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(workflow_text)}
+
+
+def collect_wrapped_check_scripts(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in RUN_WITH_TIMEOUT_STEP_RE.finditer(workflow_text)}
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate CI check scripts are protected by run_with_timeout.sh"
+  )
+  parser.add_argument(
+    "--workflow",
+    type=pathlib.Path,
+    default=pathlib.Path(".github/workflows/verify.yml"),
+    help="Path to workflow yaml",
+  )
+  parser.add_argument(
+    "--allow-unwrapped",
+    action="append",
+    default=[],
+    help="check_*.py script name allowed to be referenced without run_with_timeout.sh",
+  )
+  args = parser.parse_args()
+
+  workflow_text = args.workflow.read_text(encoding="utf-8")
+  workflow_checks = collect_workflow_check_scripts(workflow_text)
+  wrapped_checks = collect_wrapped_check_scripts(workflow_text)
+  allowed = set(args.allow_unwrapped)
+
+  unwrapped = sorted((workflow_checks - wrapped_checks) - allowed)
+  if unwrapped:
+    fail("workflow check scripts not wrapped by run_with_timeout.sh: " + ", ".join(unwrapped))
+
+  stale_allowlist = sorted(allowed - workflow_checks)
+  if stale_allowlist:
+    fail("allowlist entries not present in workflow: " + ", ".join(stale_allowlist))
+
+  print(
+    "ci-timeout-wrapper-coverage: "
+    f"workflow_checks={len(workflow_checks)} wrapped_checks={len(wrapped_checks)}"
+  )
+  print("ci-timeout-wrapper-coverage check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_ci_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_timeout_wrapper_coverage.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Unit tests for CI timeout-wrapper coverage guard."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_ci_timeout_wrapper_coverage import (  # noqa: E402
+  collect_workflow_check_scripts,
+  collect_wrapped_check_scripts,
+  main,
+)
+
+
+class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
+  def test_collect_workflow_check_scripts(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: python3 scripts/check_alpha.py",
+        "run: python3 scripts/check_beta.py --strict",
+      ]
+    )
+    self.assertEqual(
+      collect_workflow_check_scripts(workflow_text),
+      {"check_alpha.py", "check_beta.py"},
+    )
+
+  def test_collect_wrapped_check_scripts(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_alpha.py",
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_beta.py --strict",
+      ]
+    )
+    self.assertEqual(
+      collect_wrapped_check_scripts(workflow_text),
+      {"check_alpha.py", "check_beta.py"},
+    )
+
+  def test_main_passes_when_all_check_scripts_are_wrapped(self) -> None:
+    workflow_text = (
+      "run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "
+      '"check" -- python3 scripts/check_alpha.py\n'
+      "run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "
+      '"check" -- python3 scripts/check_beta.py --json-out out/x.json\n'
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = ["check_ci_timeout_wrapper_coverage.py", "--workflow", str(workflow)]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_check_script_is_unwrapped(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py",
+        "run: python3 scripts/check_beta.py",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = ["check_ci_timeout_wrapper_coverage.py", "--workflow", str(workflow)]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_passes_for_allowlisted_unwrapped_script(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py",
+        "run: python3 scripts/check_beta.py",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--allow-unwrapped",
+          "check_beta.py",
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_on_stale_allowlist(self) -> None:
+    workflow_text = "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py\n"
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--allow-unwrapped",
+          "check_beta.py",
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
Adds a fail-closed CI guard that enforces every workflow-referenced `scripts/check_*.py` is executed through `scripts/run_with_timeout.sh`.

## Changes
- add `scripts/check_ci_timeout_wrapper_coverage.py`
- add unit tests in `scripts/test_check_ci_timeout_wrapper_coverage.py`
- wire new guard into `.github/workflows/verify.yml`

## Validation
- `python3 scripts/check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/check_ci_test_coverage.py`
- `python3 scripts/check_script_test_pairs.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a fail-closed CI gate that can block merges if the workflow format changes or the regex misses a valid invocation pattern.
> 
> **Overview**
> **Enforces timeout protection for CI check scripts.** The `verify.yml` workflow now runs a new validation step that fails if any referenced `scripts/check_*.py` is invoked without `scripts/run_with_timeout.sh`.
> 
> Adds `scripts/check_ci_timeout_wrapper_coverage.py`, which scans the workflow for `check_*.py` references, verifies they appear in `run_with_timeout.sh`-wrapped invocations (with an explicit allowlist and stale-allowlist detection), and includes unit tests in `scripts/test_check_ci_timeout_wrapper_coverage.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56ff1acc3fb1420c67e3c951cd65ac62d55aa19d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->