### PR TITLE
CI: enforce timeout-wrapper coverage for shell check scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Add elan bin to PATH
         run: echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Check Lean toolchain readiness
-        run: ./scripts/check_toolchain_readiness.sh --require lean
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check Lean toolchain readiness" -- ./scripts/check_toolchain_readiness.sh --require lean
 
       - name: Clear stale Lake packages on verity pin change
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
       - name: Check solc toolchain readiness
-        run: ./scripts/check_toolchain_readiness.sh --require solc
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check solc toolchain readiness" -- ./scripts/check_toolchain_readiness.sh --require solc
 
       - name: Validate pinned parity target
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate pinned parity target" -- python3 scripts/check_parity_target.py
@@ -213,7 +213,7 @@ jobs:
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
       - name: Check full toolchain readiness
-        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check full toolchain readiness" -- ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Download verified EDSL artifact bundle
         uses: actions/download-artifact@v4
@@ -266,7 +266,7 @@ jobs:
       - name: Install Foundry
         run: ./scripts/run_with_timeout.sh MORPHO_FOUNDRY_INSTALL_TIMEOUT_SEC 600 "Install Foundry" -- ./scripts/install_foundry.sh
       - name: Check Foundry readiness
-        run: ./scripts/check_toolchain_readiness.sh --require foundry
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check Foundry readiness" -- ./scripts/check_toolchain_readiness.sh --require foundry
 
       - name: Run Morpho Blue tests
         working-directory: morpho-blue
@@ -340,7 +340,7 @@ jobs:
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
       - name: Check full toolchain readiness
-        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check full toolchain readiness" -- ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Compile Morpho Verity artifact and enforce artifact gate
         run: ./scripts/run_with_timeout.sh MORPHO_VERITY_PARITY_CHECK_TIMEOUT_SEC 9000 "Artifact preflight gate" -- ./scripts/check_input_mode_parity.sh
@@ -423,7 +423,7 @@ jobs:
       - name: Install solc
         run: ./scripts/run_with_timeout.sh MORPHO_SOLC_INSTALL_TIMEOUT_SEC 600 "Install solc" -- ./scripts/install_solc.sh 0.8.28
       - name: Check full toolchain readiness
-        run: ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Check full toolchain readiness" -- ./scripts/check_toolchain_readiness.sh --require lean --require foundry --require solc
 
       - name: Download verified EDSL artifact bundle
         uses: actions/download-artifact@v4

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -8,9 +8,9 @@ import pathlib
 import re
 import sys
 
-WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.py)\b")
+WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
 RUN_WITH_TIMEOUT_STEP_RE = re.compile(
-  r"run_with_timeout\.sh[^\n]*\s(?:--\s+)?python3\s+scripts/(check_[A-Za-z0-9_]+\.py)\b"
+  r"run_with_timeout\.sh[^\n]*\s(?:--\s+)?(?:python3\s+)?(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 
 
@@ -41,7 +41,7 @@ def main() -> int:
     "--allow-unwrapped",
     action="append",
     default=[],
-    help="check_*.py script name allowed to be referenced without run_with_timeout.sh",
+    help="check_*.{py,sh} script name allowed to be referenced without run_with_timeout.sh",
   )
   args = parser.parse_args()
 

--- a/scripts/test_check_ci_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_timeout_wrapper_coverage.py
@@ -26,11 +26,12 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       [
         "run: python3 scripts/check_alpha.py",
         "run: python3 scripts/check_beta.py --strict",
+        "run: ./scripts/check_gamma.sh --require lean",
       ]
     )
     self.assertEqual(
       collect_workflow_check_scripts(workflow_text),
-      {"check_alpha.py", "check_beta.py"},
+      {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
     )
 
   def test_collect_wrapped_check_scripts(self) -> None:
@@ -38,11 +39,12 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       [
         "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_alpha.py",
         "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_beta.py --strict",
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- ./scripts/check_gamma.sh --require lean",
       ]
     )
     self.assertEqual(
       collect_wrapped_check_scripts(workflow_text),
-      {"check_alpha.py", "check_beta.py"},
+      {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
     )
 
   def test_main_passes_when_all_check_scripts_are_wrapped(self) -> None:
@@ -51,6 +53,8 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       '"check" -- python3 scripts/check_alpha.py\n'
       "run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "
       '"check" -- python3 scripts/check_beta.py --json-out out/x.json\n'
+      "run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "
+      '"check" -- ./scripts/check_gamma.sh --require lean\n'
     )
     with tempfile.TemporaryDirectory() as tmp_dir:
       workflow = pathlib.Path(tmp_dir) / "verify.yml"
@@ -66,7 +70,7 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
     workflow_text = "\n".join(
       [
         "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py",
-        "run: python3 scripts/check_beta.py",
+        "run: ./scripts/check_beta.sh --require solc",
       ]
     )
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -85,7 +89,7 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
     workflow_text = "\n".join(
       [
         "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py",
-        "run: python3 scripts/check_beta.py",
+        "run: ./scripts/check_beta.sh --require solc",
       ]
     )
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -98,7 +102,7 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
           "--workflow",
           str(workflow),
           "--allow-unwrapped",
-          "check_beta.py",
+          "check_beta.sh",
         ]
         self.assertEqual(main(), 0)
       finally:


### PR DESCRIPTION
## Summary
Extend CI timeout-wrapper enforcement to include `scripts/check_*.sh` validators, and wrap existing shell check steps in `verify.yml`.

## Changes
- Expand `scripts/check_ci_timeout_wrapper_coverage.py` to detect both `check_*.py` and `check_*.sh` workflow references.
- Expand wrapped-detection logic to accept timeout-wrapped shell invocations (for example `-- ./scripts/check_toolchain_readiness.sh`).
- Update checker help text to reflect `check_*.{py,sh}` coverage.
- Extend `scripts/test_check_ci_timeout_wrapper_coverage.py` with mixed Python/shell coverage cases.
- Wrap all `scripts/check_toolchain_readiness.sh` invocations in `.github/workflows/verify.yml` with `run_with_timeout.sh`.

## Validation
- `python3 scripts/check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_timeout_wrapper_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but regex-based detection could falsely flag (or miss) wrapped steps and fail the workflow until patterns are adjusted.
> 
> **Overview**
> **CI now enforces `run_with_timeout.sh` coverage for both Python and shell check scripts.** The timeout-wrapper coverage guard (`scripts/check_ci_timeout_wrapper_coverage.py`) is expanded from `check_*.py` to `check_*.{py,sh}`, including recognizing wrapped shell invocations.
> 
> `verify.yml` updates all `scripts/check_toolchain_readiness.sh` steps (Lean/solc/Foundry/full toolchain) to run under `run_with_timeout.sh`, and unit tests are updated to cover mixed `.py`/`.sh` references and allowlisting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04a48ff283bf682f16f629e81d9024d316396369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->