### PR TITLE
CI: enforce timeout wrapper for all workflow script invocations

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Validate CI timeout-wrapper coverage sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI timeout-wrapper coverage sync" -- python3 scripts/check_ci_timeout_wrapper_coverage.py
 
+      - name: Validate CI script timeout-wrapper coverage sync
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI script timeout-wrapper coverage sync" -- python3 scripts/check_ci_script_timeout_wrapper_coverage.py
+
       - name: Validate script-test pairing
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate script-test pairing" -- python3 scripts/check_script_test_pairs.py
 

--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail-closed check that CI script invocations run under timeout wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+WORKFLOW_SCRIPT_REF_RE = re.compile(
+  r"\b(?:python3\s+)?(?:\./)?scripts/([A-Za-z0-9_]+\.(?:py|sh))\b"
+)
+RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
+  r"(?:\./|\.\./)?scripts/run_with_timeout\.sh[^\n]*\s--\s+"
+  r"(?:(?:python3\s+)(?:\./)?scripts/|(?:\./)?scripts/)"
+  r"([A-Za-z0-9_]+\.(?:py|sh))\b"
+)
+
+
+def fail(msg: str) -> None:
+  print(f"ci-script-timeout-wrapper-coverage check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_workflow_script_references(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in WORKFLOW_SCRIPT_REF_RE.finditer(workflow_text)}
+
+
+def collect_wrapped_script_targets(workflow_text: str) -> set[str]:
+  return {match.group(1) for match in RUN_WITH_TIMEOUT_TARGET_RE.finditer(workflow_text)}
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate CI script invocations are protected by run_with_timeout.sh"
+  )
+  parser.add_argument(
+    "--workflow",
+    type=pathlib.Path,
+    default=pathlib.Path(".github/workflows/verify.yml"),
+    help="Path to workflow yaml",
+  )
+  parser.add_argument(
+    "--allow-unwrapped",
+    action="append",
+    default=[],
+    help="script name allowed to be referenced without run_with_timeout.sh",
+  )
+  args = parser.parse_args()
+
+  workflow_text = args.workflow.read_text(encoding="utf-8")
+  workflow_refs = collect_workflow_script_references(workflow_text)
+  wrapped_targets = collect_wrapped_script_targets(workflow_text)
+  allowed = set(args.allow_unwrapped)
+
+  workflow_refs.discard("run_with_timeout.sh")
+  unwrapped = sorted((workflow_refs - wrapped_targets) - allowed)
+  if unwrapped:
+    fail("workflow scripts not wrapped by run_with_timeout.sh: " + ", ".join(unwrapped))
+
+  stale_allowlist = sorted(allowed - workflow_refs)
+  if stale_allowlist:
+    fail("allowlist entries not present in workflow: " + ", ".join(stale_allowlist))
+
+  print(
+    "ci-script-timeout-wrapper-coverage: "
+    f"workflow_refs={len(workflow_refs)} wrapped_targets={len(wrapped_targets)}"
+  )
+  print("ci-script-timeout-wrapper-coverage check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_script_timeout_wrapper_coverage.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Unit tests for CI script timeout-wrapper coverage guard."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_ci_script_timeout_wrapper_coverage import (  # noqa: E402
+  collect_workflow_script_references,
+  collect_wrapped_script_targets,
+  main,
+)
+
+
+class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
+  def test_collect_workflow_script_references(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/install_lean.sh",
+        "run: python3 scripts/check_alpha.py",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_solc.sh 0.8.28",
+      ]
+    )
+    self.assertEqual(
+      collect_workflow_script_references(workflow_text),
+      {"install_lean.sh", "check_alpha.py", "run_with_timeout.sh", "install_solc.sh"},
+    )
+
+  def test_collect_wrapped_script_targets(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_solc.sh 0.8.28",
+        "run: ../scripts/run_with_timeout.sh M 1 d -- ./scripts/install_lean.sh",
+      ]
+    )
+    self.assertEqual(
+      collect_wrapped_script_targets(workflow_text),
+      {"check_alpha.py", "install_solc.sh", "install_lean.sh"},
+    )
+
+  def test_main_passes_when_all_scripts_are_wrapped(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_lean.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = ["check_ci_script_timeout_wrapper_coverage.py", "--workflow", str(workflow)]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_on_unwrapped_script(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/install_lean.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = ["check_ci_script_timeout_wrapper_coverage.py", "--workflow", str(workflow)]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_passes_for_allowlisted_unwrapped_script(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/install_lean.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_script_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--allow-unwrapped",
+          "install_lean.sh",
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_on_stale_allowlist(self) -> None:
+    workflow_text = "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_lean.sh\n"
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workflow = pathlib.Path(tmp_dir) / "verify.yml"
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_script_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--allow-unwrapped",
+          "install_solc.sh",
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
This closes the fail-closed gap from #99 by enforcing timeout-wrapper coverage for **all** workflow `scripts/*.py` and `scripts/*.sh` invocations, not only `check_*` scripts.

## Changes
- Add `scripts/check_ci_script_timeout_wrapper_coverage.py`
  - Collects workflow script references (`python3 scripts/*.py`, `./scripts/*.sh`)
  - Collects script targets invoked through `scripts/run_with_timeout.sh`
  - Fails when any workflow script is unwrapped
  - Supports allowlist with stale-entry detection
- Add unit tests in `scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- Wire guard into CI in `.github/workflows/verify.yml`

## Local validation
- `python3 scripts/check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/check_ci_test_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #99

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new fail-closed CI guard that can start failing builds if the workflow regexes mis-detect script references or new scripts are added without the timeout wrapper. Otherwise changes are limited to CI validation and unit tests.
> 
> **Overview**
> **Enforces timeout-wrapper coverage for *all* `scripts/*.py` and `scripts/*.sh` references in the main CI workflow.** A new `check_ci_script_timeout_wrapper_coverage.py` scans `.github/workflows/verify.yml` for any script invocations and fails if they are not executed via `scripts/run_with_timeout.sh`, with an optional allowlist that also fails on stale entries.
> 
> Wires this guard into the `parity-target` job in `verify.yml`, and adds focused unit tests covering reference extraction, wrapped-target detection, allowlisting, and failure cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a52d429efc166667d4bc0512a4badbb7db2e3ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->