### PR TITLE
CI: cover check_*.sh in check-coverage guard

### DIFF
--- a/scripts/check_ci_check_coverage.py
+++ b/scripts/check_ci_check_coverage.py
@@ -8,7 +8,7 @@ import pathlib
 import re
 import sys
 
-WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.py)\b")
+WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
 
 
 def fail(msg: str) -> None:
@@ -18,9 +18,10 @@ def fail(msg: str) -> None:
 
 def collect_repo_check_scripts(scripts_dir: pathlib.Path) -> set[str]:
   checks: set[str] = set()
-  for path in scripts_dir.glob("check_*.py"):
-    if path.is_file():
-      checks.add(path.name)
+  for pattern in ("check_*.py", "check_*.sh"):
+    for path in scripts_dir.glob(pattern):
+      if path.is_file():
+        checks.add(path.name)
   return checks
 
 

--- a/scripts/test_check_ci_check_coverage.py
+++ b/scripts/test_check_ci_check_coverage.py
@@ -27,14 +27,21 @@ class CheckCiCheckCoverageTests(unittest.TestCase):
       scripts_dir.mkdir()
       (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
       (scripts_dir / "check_beta.sh").write_text("", encoding="utf-8")
-      self.assertEqual(collect_repo_check_scripts(scripts_dir), {"check_alpha.py"})
+      self.assertEqual(
+        collect_repo_check_scripts(scripts_dir),
+        {"check_alpha.py", "check_beta.sh"},
+      )
 
   def test_collect_workflow_check_scripts(self) -> None:
     workflow = (
       "run: python3 scripts/check_alpha.py\n"
+      "run: ./scripts/check_beta.sh\n"
       "run: python3 scripts/test_alpha.py\n"
     )
-    self.assertEqual(collect_workflow_check_scripts(workflow), {"check_alpha.py"})
+    self.assertEqual(
+      collect_workflow_check_scripts(workflow),
+      {"check_alpha.py", "check_beta.sh"},
+    )
 
   def test_main_passes_when_repo_and_workflow_match(self) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -43,10 +50,10 @@ class CheckCiCheckCoverageTests(unittest.TestCase):
       scripts_dir = root / "scripts"
       scripts_dir.mkdir()
       (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
-      (scripts_dir / "check_beta.py").write_text("", encoding="utf-8")
+      (scripts_dir / "check_beta.sh").write_text("", encoding="utf-8")
       workflow.write_text(
         "run: python3 scripts/check_alpha.py\n"
-        "run: python3 scripts/check_beta.py\n",
+        "run: ./scripts/check_beta.sh\n",
         encoding="utf-8",
       )
 
@@ -70,7 +77,7 @@ class CheckCiCheckCoverageTests(unittest.TestCase):
       scripts_dir = root / "scripts"
       scripts_dir.mkdir()
       (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
-      (scripts_dir / "check_beta.py").write_text("", encoding="utf-8")
+      (scripts_dir / "check_beta.sh").write_text("", encoding="utf-8")
       workflow.write_text("run: python3 scripts/check_alpha.py\n", encoding="utf-8")
 
       old_argv = sys.argv
@@ -97,7 +104,7 @@ class CheckCiCheckCoverageTests(unittest.TestCase):
       (scripts_dir / "check_alpha.py").write_text("", encoding="utf-8")
       workflow.write_text(
         "run: python3 scripts/check_alpha.py\n"
-        "run: python3 scripts/check_beta.py\n",
+        "run: ./scripts/check_beta.sh\n",
         encoding="utf-8",
       )
 


### PR DESCRIPTION
## Summary
- extend `check_ci_check_coverage.py` to include both `check_*.py` and `check_*.sh`
- keep workflow reference parsing aligned with mixed Python/shell check scripts
- update unit tests to validate mixed coverage and stale shell references

## Why
`check_ci_check_coverage.py` was fail-closed only for Python check scripts. Shell check scripts were outside that guard, so newly added `check_*.sh` files could drift out of `verify.yml` coverage without detection.

## Validation
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/test_check_ci_check_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI validation logic to fail builds when shell-based `check_*.sh` scripts are missing from (or stale in) the verify workflow, which may introduce new CI failures if workflows aren’t updated.
> 
> **Overview**
> **CI check coverage now includes shell scripts.** `scripts/check_ci_check_coverage.py` is updated to detect both `check_*.py` and `check_*.sh` in the repo and to parse workflow references for either extension.
> 
> Unit tests are updated to cover mixed Python/shell checks and to assert failures for missing or stale `.sh` workflow references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb2371e578687ab45a8ec9c547917ad08da276c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->