### PR TITLE
Harden CI timeout-wrapper coverage for loop-based script execution

### DIFF
--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -16,6 +16,10 @@ RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
   r"(?:(?:python3\s+)(?:\./)?scripts/|(?:\./)?scripts/)"
   r"([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
+SHELL_TEST_LOOP_RE = re.compile(
+  r"for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+scripts/test_\*\.sh\s*;\s*do(?P<body>.*?)\bdone\b",
+  re.DOTALL,
+)
 
 
 def fail(msg: str) -> None:
@@ -29,6 +33,31 @@ def collect_workflow_script_references(workflow_text: str) -> set[str]:
 
 def collect_wrapped_script_targets(workflow_text: str) -> set[str]:
   return {match.group(1) for match in RUN_WITH_TIMEOUT_TARGET_RE.finditer(workflow_text)}
+
+
+def collect_shell_test_loop_blocks(workflow_text: str) -> list[tuple[str, str]]:
+  blocks: list[tuple[str, str]] = []
+  for match in SHELL_TEST_LOOP_RE.finditer(workflow_text):
+    loop_var = match.group(1)
+    loop_body = match.group("body")
+    blocks.append((loop_var, loop_body))
+  return blocks
+
+
+def collect_repo_shell_script_tests(scripts_dir: pathlib.Path) -> set[str]:
+  tests: set[str] = set()
+  for path in scripts_dir.glob("test_*.sh"):
+    if path.is_file():
+      tests.add(path.name)
+  return tests
+
+
+def loop_uses_timeout_wrapper(loop_var: str, loop_body: str) -> bool:
+  var_expr_re = r"(?:\$\{" + re.escape(loop_var) + r"\}|\$" + re.escape(loop_var) + r")"
+  wrapped_loop_target_re = re.compile(
+    r"run_with_timeout\.sh[\s\S]*?--\s+[\"']?\./" + var_expr_re + r"[\"']?"
+  )
+  return bool(wrapped_loop_target_re.search(loop_body))
 
 
 def main() -> int:
@@ -47,14 +76,29 @@ def main() -> int:
     default=[],
     help="script name allowed to be referenced without run_with_timeout.sh",
   )
+  parser.add_argument(
+    "--scripts-dir",
+    type=pathlib.Path,
+    default=pathlib.Path("scripts"),
+    help="Path to scripts directory",
+  )
   args = parser.parse_args()
 
   workflow_text = args.workflow.read_text(encoding="utf-8")
   workflow_refs = collect_workflow_script_references(workflow_text)
   wrapped_targets = collect_wrapped_script_targets(workflow_text)
+  shell_test_loops = collect_shell_test_loop_blocks(workflow_text)
+  shell_script_tests = collect_repo_shell_script_tests(args.scripts_dir)
   allowed = set(args.allow_unwrapped)
 
   workflow_refs.discard("run_with_timeout.sh")
+  if shell_test_loops:
+    workflow_refs.update(shell_script_tests)
+    for loop_var, loop_body in shell_test_loops:
+      if not loop_uses_timeout_wrapper(loop_var, loop_body):
+        fail(f"shell test loop variable '{loop_var}' executes without run_with_timeout.sh")
+    wrapped_targets.update(shell_script_tests)
+
   unwrapped = sorted((workflow_refs - wrapped_targets) - allowed)
   if unwrapped:
     fail("workflow scripts not wrapped by run_with_timeout.sh: " + ", ".join(unwrapped))

--- a/scripts/test_check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_script_timeout_wrapper_coverage.py
@@ -14,8 +14,10 @@ if str(SCRIPT_DIR) not in sys.path:
   sys.path.insert(0, str(SCRIPT_DIR))
 
 from check_ci_script_timeout_wrapper_coverage import (  # noqa: E402
+  collect_shell_test_loop_blocks,
   collect_workflow_script_references,
   collect_wrapped_script_targets,
+  loop_uses_timeout_wrapper,
   main,
 )
 
@@ -46,6 +48,35 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
       collect_wrapped_script_targets(workflow_text),
       {"check_alpha.py", "install_solc.sh", "install_lean.sh"},
     )
+
+  def test_collect_shell_test_loop_blocks(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: |",
+        "  for t in scripts/test_*.sh; do",
+        "    ./scripts/run_with_timeout.sh M 1 d -- \"./${t}\"",
+        "  done",
+      ]
+    )
+    self.assertEqual(len(collect_shell_test_loop_blocks(workflow_text)), 1)
+
+  def test_loop_uses_timeout_wrapper_detects_wrapped_body(self) -> None:
+    loop_body = "\n".join(
+      [
+        "  echo running",
+        "  ./scripts/run_with_timeout.sh M 1 d -- \"./${t}\"",
+      ]
+    )
+    self.assertTrue(loop_uses_timeout_wrapper("t", loop_body))
+
+  def test_loop_uses_timeout_wrapper_rejects_unwrapped_body(self) -> None:
+    loop_body = "\n".join(
+      [
+        "  echo running",
+        "  \"./${t}\"",
+      ]
+    )
+    self.assertFalse(loop_uses_timeout_wrapper("t", loop_body))
 
   def test_main_passes_when_all_scripts_are_wrapped(self) -> None:
     workflow_text = "\n".join(
@@ -119,6 +150,67 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
           str(workflow),
           "--allow-unwrapped",
           "install_solc.sh",
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_passes_for_wrapped_shell_test_loop(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: |",
+        "  for t in scripts/test_*.sh; do",
+        "    ./scripts/run_with_timeout.sh M 1 d -- \"./${t}\"",
+        "  done",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      (scripts_dir / "test_beta.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_script_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_for_unwrapped_shell_test_loop(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: |",
+        "  for t in scripts/test_*.sh; do",
+        "    \"./${t}\"",
+        "  done",
+      ]
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      root = pathlib.Path(tmp_dir)
+      workflow = root / "verify.yml"
+      scripts_dir = root / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "test_alpha.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      workflow.write_text(workflow_text, encoding="utf-8")
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_ci_script_timeout_wrapper_coverage.py",
+          "--workflow",
+          str(workflow),
+          "--scripts-dir",
+          str(scripts_dir),
         ]
         with self.assertRaises(SystemExit) as ctx:
           main()


### PR DESCRIPTION
## Summary
- extend `check_ci_script_timeout_wrapper_coverage.py` to detect shell-test loop blocks (`for t in scripts/test_*.sh; do ... done`)
- require loop variables to execute via `run_with_timeout.sh` (e.g. `-- "./${t}"`)
- infer concrete shell test targets from `scripts/test_*.sh` when loop mode is used, so coverage remains fail-closed
- add regression unit tests for wrapped and unwrapped loop variants

## Why
The previous checker only matched direct script references. Variable-based loop execution in CI could bypass wrapper coverage detection.

## Validation
- `python3 scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_script_timeout_wrapper_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #103

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens CI validation logic and may introduce false positives/CI failures if workflow loop patterns or quoting differ from the new regex expectations.
> 
> **Overview**
> **Hardens CI timeout-wrapper enforcement** by teaching `check_ci_script_timeout_wrapper_coverage.py` to detect `for ... in scripts/test_*.sh; do ... done` blocks and require the loop variable to be executed via `run_with_timeout.sh`.
> 
> When loop mode is detected, the checker now enumerates concrete `scripts/test_*.sh` files via a new `--scripts-dir` option and treats them as referenced+wrapped targets (fail-closed). Adds unit tests covering wrapped vs unwrapped loop bodies and the new CLI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9675a0c0103a563ad9f6dbe6da29c1198276fdaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->