### PR TITLE
Fix CI timeout guards for multiline run_with_timeout invocations

### DIFF
--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -16,6 +16,7 @@ RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
   r"(?:(?:python3\s+)(?:\./)?scripts/|(?:\./)?scripts/)"
   r"([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
+LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
 SHELL_TEST_LOOP_RE = re.compile(
   r"for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+scripts/test_\*\.sh\s*;\s*do(?P<body>.*?)\bdone\b",
   re.DOTALL,
@@ -32,7 +33,8 @@ def collect_workflow_script_references(workflow_text: str) -> set[str]:
 
 
 def collect_wrapped_script_targets(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in RUN_WITH_TIMEOUT_TARGET_RE.finditer(workflow_text)}
+  normalized = LINE_CONTINUATION_RE.sub(" ", workflow_text)
+  return {match.group(1) for match in RUN_WITH_TIMEOUT_TARGET_RE.finditer(normalized)}
 
 
 def collect_shell_test_loop_blocks(workflow_text: str) -> list[tuple[str, str]]:

--- a/scripts/check_ci_timeout_defaults.py
+++ b/scripts/check_ci_timeout_defaults.py
@@ -11,6 +11,7 @@ import sys
 RUN_WITH_TIMEOUT_RE = re.compile(r"run_with_timeout\.sh\s+([A-Z0-9_]+)\s+([0-9]+)\b")
 ENV_TIMEOUT_RE = re.compile(r"\b([A-Z0-9_]*TIMEOUT[A-Z0-9_]*)\s*:\s*\"([0-9]+)\"")
 SCRIPT_TIMEOUT_RE = re.compile(r"\b([A-Z0-9_]*TIMEOUT[A-Z0-9_]*)\b")
+LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
 
 IGNORED_VARS = {
   # This timeout is intentionally overridden in timeout-wrapper tests.
@@ -51,8 +52,9 @@ def parse_timeout_env_file(path: pathlib.Path) -> dict[str, int]:
 
 
 def collect_run_timeout_defaults(workflow_text: str) -> dict[str, set[int]]:
+  normalized = LINE_CONTINUATION_RE.sub(" ", workflow_text)
   seen: dict[str, set[int]] = {}
-  for var, default in RUN_WITH_TIMEOUT_RE.findall(workflow_text):
+  for var, default in RUN_WITH_TIMEOUT_RE.findall(normalized):
     seen.setdefault(var, set()).add(int(default))
   return seen
 

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -12,6 +12,7 @@ WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\
 RUN_WITH_TIMEOUT_STEP_RE = re.compile(
   r"run_with_timeout\.sh[^\n]*\s(?:--\s+)?(?:python3\s+)?(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
 )
+LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
 
 
 def fail(msg: str) -> None:
@@ -24,7 +25,8 @@ def collect_workflow_check_scripts(workflow_text: str) -> set[str]:
 
 
 def collect_wrapped_check_scripts(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in RUN_WITH_TIMEOUT_STEP_RE.finditer(workflow_text)}
+  normalized = LINE_CONTINUATION_RE.sub(" ", workflow_text)
+  return {match.group(1) for match in RUN_WITH_TIMEOUT_STEP_RE.finditer(normalized)}
 
 
 def main() -> int:

--- a/scripts/test_check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_script_timeout_wrapper_coverage.py
@@ -49,6 +49,15 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
       {"check_alpha.py", "install_solc.sh", "install_lean.sh"},
     )
 
+  def test_collect_wrapped_script_targets_supports_line_continuation(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 d \\",
+        "  -- ./scripts/install_solc.sh 0.8.28",
+      ]
+    )
+    self.assertEqual(collect_wrapped_script_targets(workflow_text), {"install_solc.sh"})
+
   def test_collect_shell_test_loop_blocks(self) -> None:
     workflow_text = "\n".join(
       [

--- a/scripts/test_check_ci_timeout_defaults.py
+++ b/scripts/test_check_ci_timeout_defaults.py
@@ -37,6 +37,13 @@ class CheckCiTimeoutDefaultsTests(unittest.TestCase):
     )
     self.assertEqual(collect_run_timeout_defaults(workflow), {"A_TIMEOUT": {10}, "B_TIMEOUT": {20}})
 
+  def test_collect_run_timeout_defaults_supports_line_continuation(self) -> None:
+    workflow = (
+      "run: ./scripts/run_with_timeout.sh \\\n"
+      "  A_TIMEOUT 10 \"A\" -- cmd\n"
+    )
+    self.assertEqual(collect_run_timeout_defaults(workflow), {"A_TIMEOUT": {10}})
+
   def test_collect_timeout_env_literals(self) -> None:
     workflow = (
       "env:\n"

--- a/scripts/test_check_ci_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_timeout_wrapper_coverage.py
@@ -47,6 +47,15 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
     )
 
+  def test_collect_wrapped_check_scripts_supports_line_continuation(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 check \\",
+        "  -- python3 scripts/check_alpha.py",
+      ]
+    )
+    self.assertEqual(collect_wrapped_check_scripts(workflow_text), {"check_alpha.py"})
+
   def test_main_passes_when_all_check_scripts_are_wrapped(self) -> None:
     workflow_text = (
       "run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "


### PR DESCRIPTION
## Summary
- normalize shell line-continuation sequences (`\\` + newline + indentation) before timeout-wrapper parsing
- harden CI guard extractors so multiline `run_with_timeout.sh` calls are recognized
- add regression tests for multiline command forms

## Changes
- `scripts/check_ci_timeout_wrapper_coverage.py`
  - normalize line continuations before scanning wrapped `check_*` targets
- `scripts/check_ci_script_timeout_wrapper_coverage.py`
  - normalize line continuations before scanning wrapped script targets
- `scripts/check_ci_timeout_defaults.py`
  - normalize line continuations before extracting `run_with_timeout.sh` default values
- tests:
  - `scripts/test_check_ci_timeout_wrapper_coverage.py`
  - `scripts/test_check_ci_script_timeout_wrapper_coverage.py`
  - `scripts/test_check_ci_timeout_defaults.py`

## Validation
- `python3 scripts/test_check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_timeout_defaults.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Fixes #105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI validation scripts and tests; primary risk is mis-parsing workflow YAML leading to false CI failures or missed coverage checks.
> 
> **Overview**
> **Improves robustness of CI timeout-guard parsing** by normalizing shell line-continuation sequences (`\\` + newline + indentation) before regex-scanning workflow text.
> 
> This updates the `check_ci_*` scripts that (1) enforce `run_with_timeout.sh` coverage for `check_*` scripts and general `scripts/*.py|.sh` invocations and (2) extract `run_with_timeout.sh` default timeout values, and adds regression tests covering multiline `run_with_timeout.sh` command forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a2b187a04d4081db86d871eb6ca9dbd89645165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->