### PR TITLE
Harden CI guards to parse workflow run commands only

### DIFF
--- a/scripts/check_ci_check_coverage.py
+++ b/scripts/check_ci_check_coverage.py
@@ -9,6 +9,8 @@ import re
 import sys
 
 WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
+RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
+RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
@@ -25,8 +27,55 @@ def collect_repo_check_scripts(scripts_dir: pathlib.Path) -> set[str]:
   return checks
 
 
+def extract_workflow_run_text(workflow_text: str) -> str:
+  commands: list[str] = []
+  lines = workflow_text.splitlines()
+  i = 0
+  while i < len(lines):
+    line = lines[i]
+    match = RUN_STEP_RE.match(line)
+    if match is None:
+      i += 1
+      continue
+
+    run_indent = len(match.group(1))
+    tail = match.group(2).strip()
+    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
+      line_parts = [tail]
+      i += 1
+      while i < len(lines):
+        candidate = lines[i]
+        stripped = candidate.lstrip(" ")
+        if not stripped:
+          break
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        line_parts.append(stripped)
+        i += 1
+      commands.append("\n".join(line_parts))
+      continue
+
+    i += 1
+    block_lines: list[str] = []
+    while i < len(lines):
+      candidate = lines[i]
+      stripped = candidate.lstrip(" ")
+      if stripped:
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        block_lines.append(stripped)
+      else:
+        block_lines.append("")
+      i += 1
+    commands.append("\n".join(block_lines))
+  return "\n".join(commands)
+
+
 def collect_workflow_check_scripts(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(workflow_text)}
+  run_text = extract_workflow_run_text(workflow_text)
+  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(run_text)}
 
 
 def main() -> int:

--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -12,11 +12,13 @@ WORKFLOW_SCRIPT_REF_RE = re.compile(
   r"\b(?:python3\s+)?(?:\./)?scripts/([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
-  r"(?:\./|\.\./)?scripts/run_with_timeout\.sh[^\n]*\s--\s+"
-  r"(?:(?:python3\s+)(?:\./)?scripts/|(?:\./)?scripts/)"
+  r"(?:\./|\.\./)?scripts/run_with_timeout\.sh[^\n]*[ \t]+--[ \t]+"
+  r"(?:(?:python3[ \t]+)(?:\./)?scripts/|(?:\./)?scripts/)"
   r"([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
+RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
+RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 SHELL_TEST_LOOP_RE = re.compile(
   r"for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+scripts/test_\*\.sh\s*;\s*do(?P<body>.*?)\bdone\b",
   re.DOTALL,
@@ -28,18 +30,67 @@ def fail(msg: str) -> None:
   raise SystemExit(1)
 
 
+def extract_workflow_run_text(workflow_text: str) -> str:
+  commands: list[str] = []
+  lines = workflow_text.splitlines()
+  i = 0
+  while i < len(lines):
+    line = lines[i]
+    match = RUN_STEP_RE.match(line)
+    if match is None:
+      i += 1
+      continue
+
+    run_indent = len(match.group(1))
+    tail = match.group(2).strip()
+    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
+      line_parts = [tail]
+      i += 1
+      while i < len(lines):
+        candidate = lines[i]
+        stripped = candidate.lstrip(" ")
+        if not stripped:
+          break
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        line_parts.append(stripped)
+        i += 1
+      commands.append("\n".join(line_parts))
+      continue
+
+    i += 1
+    block_lines: list[str] = []
+    while i < len(lines):
+      candidate = lines[i]
+      stripped = candidate.lstrip(" ")
+      if stripped:
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        block_lines.append(stripped)
+      else:
+        block_lines.append("")
+      i += 1
+    commands.append("\n".join(block_lines))
+  return "\n".join(commands)
+
+
 def collect_workflow_script_references(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in WORKFLOW_SCRIPT_REF_RE.finditer(workflow_text)}
+  run_text = extract_workflow_run_text(workflow_text)
+  return {match.group(1) for match in WORKFLOW_SCRIPT_REF_RE.finditer(run_text)}
 
 
 def collect_wrapped_script_targets(workflow_text: str) -> set[str]:
-  normalized = LINE_CONTINUATION_RE.sub(" ", workflow_text)
+  run_text = extract_workflow_run_text(workflow_text)
+  normalized = LINE_CONTINUATION_RE.sub(" ", run_text)
   return {match.group(1) for match in RUN_WITH_TIMEOUT_TARGET_RE.finditer(normalized)}
 
 
 def collect_shell_test_loop_blocks(workflow_text: str) -> list[tuple[str, str]]:
+  run_text = extract_workflow_run_text(workflow_text)
   blocks: list[tuple[str, str]] = []
-  for match in SHELL_TEST_LOOP_RE.finditer(workflow_text):
+  for match in SHELL_TEST_LOOP_RE.finditer(run_text):
     loop_var = match.group(1)
     loop_body = match.group("body")
     blocks.append((loop_var, loop_body))

--- a/scripts/check_ci_test_coverage.py
+++ b/scripts/check_ci_test_coverage.py
@@ -13,6 +13,8 @@ WORKFLOW_PY_DISCOVER_RE = re.compile(
   r"python3\s+-m\s+unittest\s+discover[^\n]*-s\s+scripts[^\n]*-p\s+['\"]test_\*\.py['\"]"
 )
 WORKFLOW_SH_GLOB_RE = re.compile(r"\bscripts/test_\*\.sh\b")
+RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
+RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
@@ -40,16 +42,65 @@ def collect_repo_shell_script_tests(scripts_dir: pathlib.Path) -> set[str]:
   return tests
 
 
+def extract_workflow_run_text(workflow_text: str) -> str:
+  commands: list[str] = []
+  lines = workflow_text.splitlines()
+  i = 0
+  while i < len(lines):
+    line = lines[i]
+    match = RUN_STEP_RE.match(line)
+    if match is None:
+      i += 1
+      continue
+
+    run_indent = len(match.group(1))
+    tail = match.group(2).strip()
+    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
+      line_parts = [tail]
+      i += 1
+      while i < len(lines):
+        candidate = lines[i]
+        stripped = candidate.lstrip(" ")
+        if not stripped:
+          break
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        line_parts.append(stripped)
+        i += 1
+      commands.append("\n".join(line_parts))
+      continue
+
+    i += 1
+    block_lines: list[str] = []
+    while i < len(lines):
+      candidate = lines[i]
+      stripped = candidate.lstrip(" ")
+      if stripped:
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        block_lines.append(stripped)
+      else:
+        block_lines.append("")
+      i += 1
+    commands.append("\n".join(block_lines))
+  return "\n".join(commands)
+
+
 def collect_workflow_script_tests(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in WORKFLOW_TEST_REF_RE.finditer(workflow_text)}
+  run_text = extract_workflow_run_text(workflow_text)
+  return {match.group(1) for match in WORKFLOW_TEST_REF_RE.finditer(run_text)}
 
 
 def has_workflow_python_discovery(workflow_text: str) -> bool:
-  return bool(WORKFLOW_PY_DISCOVER_RE.search(workflow_text))
+  run_text = extract_workflow_run_text(workflow_text)
+  return bool(WORKFLOW_PY_DISCOVER_RE.search(run_text))
 
 
 def has_workflow_shell_glob(workflow_text: str) -> bool:
-  return bool(WORKFLOW_SH_GLOB_RE.search(workflow_text))
+  run_text = extract_workflow_run_text(workflow_text)
+  return bool(WORKFLOW_SH_GLOB_RE.search(run_text))
 
 
 def main() -> int:

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -10,9 +10,12 @@ import sys
 
 WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
 RUN_WITH_TIMEOUT_STEP_RE = re.compile(
-  r"run_with_timeout\.sh[^\n]*\s(?:--\s+)?(?:python3\s+)?(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
+  r"run_with_timeout\.sh[^\n]*[ \t]+(?:--[ \t]+)?(?:python3[ \t]+)?"
+  r"(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
+RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
+RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
@@ -20,12 +23,60 @@ def fail(msg: str) -> None:
   raise SystemExit(1)
 
 
+def extract_workflow_run_text(workflow_text: str) -> str:
+  commands: list[str] = []
+  lines = workflow_text.splitlines()
+  i = 0
+  while i < len(lines):
+    line = lines[i]
+    match = RUN_STEP_RE.match(line)
+    if match is None:
+      i += 1
+      continue
+
+    run_indent = len(match.group(1))
+    tail = match.group(2).strip()
+    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
+      line_parts = [tail]
+      i += 1
+      while i < len(lines):
+        candidate = lines[i]
+        stripped = candidate.lstrip(" ")
+        if not stripped:
+          break
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        line_parts.append(stripped)
+        i += 1
+      commands.append("\n".join(line_parts))
+      continue
+
+    i += 1
+    block_lines: list[str] = []
+    while i < len(lines):
+      candidate = lines[i]
+      stripped = candidate.lstrip(" ")
+      if stripped:
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        block_lines.append(stripped)
+      else:
+        block_lines.append("")
+      i += 1
+    commands.append("\n".join(block_lines))
+  return "\n".join(commands)
+
+
 def collect_workflow_check_scripts(workflow_text: str) -> set[str]:
-  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(workflow_text)}
+  run_text = extract_workflow_run_text(workflow_text)
+  return {match.group(1) for match in WORKFLOW_CHECK_REF_RE.finditer(run_text)}
 
 
 def collect_wrapped_check_scripts(workflow_text: str) -> set[str]:
-  normalized = LINE_CONTINUATION_RE.sub(" ", workflow_text)
+  run_text = extract_workflow_run_text(workflow_text)
+  normalized = LINE_CONTINUATION_RE.sub(" ", run_text)
   return {match.group(1) for match in RUN_WITH_TIMEOUT_STEP_RE.finditer(normalized)}
 
 

--- a/scripts/test_check_ci_check_coverage.py
+++ b/scripts/test_check_ci_check_coverage.py
@@ -43,6 +43,14 @@ class CheckCiCheckCoverageTests(unittest.TestCase):
       {"check_alpha.py", "check_beta.sh"},
     )
 
+  def test_collect_workflow_check_scripts_ignores_non_run_references(self) -> None:
+    workflow = (
+      "# docs: scripts/check_from_comment.py\n"
+      "name: scripts/check_from_name.sh\n"
+      "run: python3 scripts/check_alpha.py\n"
+    )
+    self.assertEqual(collect_workflow_check_scripts(workflow), {"check_alpha.py"})
+
   def test_main_passes_when_repo_and_workflow_match(self) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
       root = pathlib.Path(tmp_dir)

--- a/scripts/test_check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_script_timeout_wrapper_coverage.py
@@ -36,6 +36,16 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
       {"install_lean.sh", "check_alpha.py", "run_with_timeout.sh", "install_solc.sh"},
     )
 
+  def test_collect_workflow_script_references_ignores_non_run_references(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "# scripts/install_from_comment.sh",
+        "name: scripts/install_from_name.sh",
+        "run: ./scripts/install_lean.sh",
+      ]
+    )
+    self.assertEqual(collect_workflow_script_references(workflow_text), {"install_lean.sh"})
+
   def test_collect_wrapped_script_targets(self) -> None:
     workflow_text = "\n".join(
       [
@@ -48,6 +58,15 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
       collect_wrapped_script_targets(workflow_text),
       {"check_alpha.py", "install_solc.sh", "install_lean.sh"},
     )
+
+  def test_collect_wrapped_script_targets_does_not_cross_lines(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_lean.sh",
+        "run: ./scripts/install_solc.sh 0.8.28",
+      ]
+    )
+    self.assertEqual(collect_wrapped_script_targets(workflow_text), {"install_lean.sh"})
 
   def test_collect_wrapped_script_targets_supports_line_continuation(self) -> None:
     workflow_text = "\n".join(

--- a/scripts/test_check_ci_test_coverage.py
+++ b/scripts/test_check_ci_test_coverage.py
@@ -44,6 +44,14 @@ class CheckCiTestCoverageTests(unittest.TestCase):
     )
     self.assertEqual(collect_workflow_script_tests(workflow), {"test_alpha.py", "test_beta.sh"})
 
+  def test_collect_workflow_script_tests_ignores_non_run_references(self) -> None:
+    workflow = (
+      "# docs: scripts/test_from_comment.py\n"
+      "name: scripts/test_from_name.sh\n"
+      "run: python3 scripts/test_alpha.py\n"
+    )
+    self.assertEqual(collect_workflow_script_tests(workflow), {"test_alpha.py"})
+
   def test_detection_of_discovery_modes(self) -> None:
     workflow = (
       "run: python3 -m unittest discover -s scripts -p 'test_*.py'\n"
@@ -51,6 +59,15 @@ class CheckCiTestCoverageTests(unittest.TestCase):
     )
     self.assertTrue(has_workflow_python_discovery(workflow))
     self.assertTrue(has_workflow_shell_glob(workflow))
+
+  def test_detection_of_discovery_modes_ignores_non_run_references(self) -> None:
+    workflow = (
+      "# python3 -m unittest discover -s scripts -p 'test_*.py'\n"
+      "name: scripts/test_*.sh\n"
+      "run: echo check\n"
+    )
+    self.assertFalse(has_workflow_python_discovery(workflow))
+    self.assertFalse(has_workflow_shell_glob(workflow))
 
   def test_main_passes_when_repo_and_workflow_match(self) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/test_check_ci_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_timeout_wrapper_coverage.py
@@ -34,6 +34,16 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
     )
 
+  def test_collect_workflow_check_scripts_ignores_non_run_references(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "# docs: scripts/check_from_comment.py",
+        "name: scripts/check_from_name.sh",
+        "run: python3 scripts/check_alpha.py",
+      ]
+    )
+    self.assertEqual(collect_workflow_check_scripts(workflow_text), {"check_alpha.py"})
+
   def test_collect_wrapped_check_scripts(self) -> None:
     workflow_text = "\n".join(
       [
@@ -46,6 +56,15 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
       collect_wrapped_check_scripts(workflow_text),
       {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
     )
+
+  def test_collect_wrapped_check_scripts_does_not_cross_lines(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_alpha.py",
+        "run: ./scripts/check_beta.sh --require solc",
+      ]
+    )
+    self.assertEqual(collect_wrapped_check_scripts(workflow_text), {"check_alpha.py"})
 
   def test_collect_wrapped_check_scripts_supports_line_continuation(self) -> None:
     workflow_text = "\n".join(


### PR DESCRIPTION
## Summary
Closes #107

Harden CI guard parsing so script references are extracted from executed `run:` commands only, instead of scanning the raw workflow YAML text.

## What changed
- Updated parsers in:
  - `scripts/check_ci_check_coverage.py`
  - `scripts/check_ci_test_coverage.py`
  - `scripts/check_ci_timeout_wrapper_coverage.py`
  - `scripts/check_ci_script_timeout_wrapper_coverage.py`
- Added run extraction support for:
  - single-line `run:` steps
  - block scalar `run: |` / `run: >` steps
  - indented continuation lines after single-line `run:` steps
- Tightened timeout-wrapper regexes to avoid cross-line matching.

## Tests
- `python3 scripts/test_check_ci_check_coverage.py`
- `python3 scripts/test_check_ci_test_coverage.py`
- `python3 scripts/test_check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how CI guard scripts parse workflow YAML; bugs could cause false failures or allow missing/unwrapped scripts to slip through.
> 
> **Overview**
> **Hardens CI guard parsing to only consider executed workflow commands.** The coverage/timeout-wrapper checks now extract and scan just `run:` step bodies (including `run: |`/`run: >` blocks and indented continuations) instead of grepping the full workflow file, so comments and metadata no longer count as references.
> 
> **Tightens timeout-wrapper matching.** Wrapper regexes are updated to be whitespace-aware and avoid cross-line matches, and new unit tests cover ignoring non-`run:` references and ensuring wrapper detection doesn’t bleed across adjacent steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2251bf627a54bbcb709a303e967c054a2c88fba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->