### PR TITLE
Refactor CI guards to share workflow run-step parser

### DIFF
--- a/scripts/check_ci_check_coverage.py
+++ b/scripts/check_ci_check_coverage.py
@@ -8,9 +8,9 @@ import pathlib
 import re
 import sys
 
+from workflow_run_parser import extract_workflow_run_text
+
 WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
-RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
-RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
@@ -25,52 +25,6 @@ def collect_repo_check_scripts(scripts_dir: pathlib.Path) -> set[str]:
       if path.is_file():
         checks.add(path.name)
   return checks
-
-
-def extract_workflow_run_text(workflow_text: str) -> str:
-  commands: list[str] = []
-  lines = workflow_text.splitlines()
-  i = 0
-  while i < len(lines):
-    line = lines[i]
-    match = RUN_STEP_RE.match(line)
-    if match is None:
-      i += 1
-      continue
-
-    run_indent = len(match.group(1))
-    tail = match.group(2).strip()
-    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
-      line_parts = [tail]
-      i += 1
-      while i < len(lines):
-        candidate = lines[i]
-        stripped = candidate.lstrip(" ")
-        if not stripped:
-          break
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        line_parts.append(stripped)
-        i += 1
-      commands.append("\n".join(line_parts))
-      continue
-
-    i += 1
-    block_lines: list[str] = []
-    while i < len(lines):
-      candidate = lines[i]
-      stripped = candidate.lstrip(" ")
-      if stripped:
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        block_lines.append(stripped)
-      else:
-        block_lines.append("")
-      i += 1
-    commands.append("\n".join(block_lines))
-  return "\n".join(commands)
 
 
 def collect_workflow_check_scripts(workflow_text: str) -> set[str]:

--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -8,6 +8,8 @@ import pathlib
 import re
 import sys
 
+from workflow_run_parser import extract_workflow_run_text
+
 WORKFLOW_SCRIPT_REF_RE = re.compile(
   r"\b(?:python3\s+)?(?:\./)?scripts/([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
@@ -17,8 +19,6 @@ RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
   r"([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
-RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
-RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 SHELL_TEST_LOOP_RE = re.compile(
   r"for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+scripts/test_\*\.sh\s*;\s*do(?P<body>.*?)\bdone\b",
   re.DOTALL,
@@ -28,52 +28,6 @@ SHELL_TEST_LOOP_RE = re.compile(
 def fail(msg: str) -> None:
   print(f"ci-script-timeout-wrapper-coverage check failed: {msg}", file=sys.stderr)
   raise SystemExit(1)
-
-
-def extract_workflow_run_text(workflow_text: str) -> str:
-  commands: list[str] = []
-  lines = workflow_text.splitlines()
-  i = 0
-  while i < len(lines):
-    line = lines[i]
-    match = RUN_STEP_RE.match(line)
-    if match is None:
-      i += 1
-      continue
-
-    run_indent = len(match.group(1))
-    tail = match.group(2).strip()
-    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
-      line_parts = [tail]
-      i += 1
-      while i < len(lines):
-        candidate = lines[i]
-        stripped = candidate.lstrip(" ")
-        if not stripped:
-          break
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        line_parts.append(stripped)
-        i += 1
-      commands.append("\n".join(line_parts))
-      continue
-
-    i += 1
-    block_lines: list[str] = []
-    while i < len(lines):
-      candidate = lines[i]
-      stripped = candidate.lstrip(" ")
-      if stripped:
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        block_lines.append(stripped)
-      else:
-        block_lines.append("")
-      i += 1
-    commands.append("\n".join(block_lines))
-  return "\n".join(commands)
 
 
 def collect_workflow_script_references(workflow_text: str) -> set[str]:

--- a/scripts/check_ci_test_coverage.py
+++ b/scripts/check_ci_test_coverage.py
@@ -8,13 +8,13 @@ import pathlib
 import re
 import sys
 
+from workflow_run_parser import extract_workflow_run_text
+
 WORKFLOW_TEST_REF_RE = re.compile(r"\bscripts/(test_[A-Za-z0-9_]+\.(?:py|sh))\b")
 WORKFLOW_PY_DISCOVER_RE = re.compile(
   r"python3\s+-m\s+unittest\s+discover[^\n]*-s\s+scripts[^\n]*-p\s+['\"]test_\*\.py['\"]"
 )
 WORKFLOW_SH_GLOB_RE = re.compile(r"\bscripts/test_\*\.sh\b")
-RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
-RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
@@ -40,52 +40,6 @@ def collect_repo_shell_script_tests(scripts_dir: pathlib.Path) -> set[str]:
     if path.is_file():
       tests.add(path.name)
   return tests
-
-
-def extract_workflow_run_text(workflow_text: str) -> str:
-  commands: list[str] = []
-  lines = workflow_text.splitlines()
-  i = 0
-  while i < len(lines):
-    line = lines[i]
-    match = RUN_STEP_RE.match(line)
-    if match is None:
-      i += 1
-      continue
-
-    run_indent = len(match.group(1))
-    tail = match.group(2).strip()
-    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
-      line_parts = [tail]
-      i += 1
-      while i < len(lines):
-        candidate = lines[i]
-        stripped = candidate.lstrip(" ")
-        if not stripped:
-          break
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        line_parts.append(stripped)
-        i += 1
-      commands.append("\n".join(line_parts))
-      continue
-
-    i += 1
-    block_lines: list[str] = []
-    while i < len(lines):
-      candidate = lines[i]
-      stripped = candidate.lstrip(" ")
-      if stripped:
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        block_lines.append(stripped)
-      else:
-        block_lines.append("")
-      i += 1
-    commands.append("\n".join(block_lines))
-  return "\n".join(commands)
 
 
 def collect_workflow_script_tests(workflow_text: str) -> set[str]:

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -8,65 +8,19 @@ import pathlib
 import re
 import sys
 
+from workflow_run_parser import extract_workflow_run_text
+
 WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
 RUN_WITH_TIMEOUT_STEP_RE = re.compile(
   r"run_with_timeout\.sh[^\n]*[ \t]+(?:--[ \t]+)?(?:python3[ \t]+)?"
   r"(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
-RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
-RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def fail(msg: str) -> None:
   print(f"ci-timeout-wrapper-coverage check failed: {msg}", file=sys.stderr)
   raise SystemExit(1)
-
-
-def extract_workflow_run_text(workflow_text: str) -> str:
-  commands: list[str] = []
-  lines = workflow_text.splitlines()
-  i = 0
-  while i < len(lines):
-    line = lines[i]
-    match = RUN_STEP_RE.match(line)
-    if match is None:
-      i += 1
-      continue
-
-    run_indent = len(match.group(1))
-    tail = match.group(2).strip()
-    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
-      line_parts = [tail]
-      i += 1
-      while i < len(lines):
-        candidate = lines[i]
-        stripped = candidate.lstrip(" ")
-        if not stripped:
-          break
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        line_parts.append(stripped)
-        i += 1
-      commands.append("\n".join(line_parts))
-      continue
-
-    i += 1
-    block_lines: list[str] = []
-    while i < len(lines):
-      candidate = lines[i]
-      stripped = candidate.lstrip(" ")
-      if stripped:
-        indent = len(candidate) - len(stripped)
-        if indent <= run_indent:
-          break
-        block_lines.append(stripped)
-      else:
-        block_lines.append("")
-      i += 1
-    commands.append("\n".join(block_lines))
-  return "\n".join(commands)
 
 
 def collect_workflow_check_scripts(workflow_text: str) -> set[str]:

--- a/scripts/test_workflow_run_parser.py
+++ b/scripts/test_workflow_run_parser.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Unit tests for workflow run-step parser helper."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from workflow_run_parser import extract_workflow_run_text  # noqa: E402
+
+
+class WorkflowRunParserTests(unittest.TestCase):
+  def test_extract_workflow_run_text_ignores_non_run_fields(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "name: scripts/check_from_name.py",
+        "jobs:",
+        "  test:",
+        "    steps:",
+        "      - name: Example scripts/check_from_step_name.py",
+        "        run: python3 scripts/check_real.py",
+      ]
+    )
+    self.assertEqual(extract_workflow_run_text(workflow_text), "python3 scripts/check_real.py")
+
+  def test_extract_workflow_run_text_handles_block_scalar(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "jobs:",
+        "  test:",
+        "    steps:",
+        "      - name: Step",
+        "        run: |",
+        "          echo before",
+        "          python3 scripts/check_alpha.py",
+      ]
+    )
+    self.assertEqual(
+      extract_workflow_run_text(workflow_text),
+      "echo before\npython3 scripts/check_alpha.py",
+    )
+
+  def test_extract_workflow_run_text_handles_inline_with_nested_lines(self) -> None:
+    workflow_text = "\n".join(
+      [
+        "jobs:",
+        "  test:",
+        "    steps:",
+        "      - name: Step",
+        "        run: python3 scripts/check_alpha.py \\",
+        "          --strict",
+        "        env:",
+        "          FOO: bar",
+      ]
+    )
+    self.assertEqual(
+      extract_workflow_run_text(workflow_text),
+      "python3 scripts/check_alpha.py \\\n--strict",
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/workflow_run_parser.py
+++ b/scripts/workflow_run_parser.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Utilities for extracting executable `run:` command text from CI workflow YAML."""
+
+from __future__ import annotations
+
+import re
+
+RUN_STEP_RE = re.compile(r"^(\s*)run:\s*(.*)$")
+RUN_BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
+
+
+def extract_workflow_run_text(workflow_text: str) -> str:
+  """Return concatenated command text from workflow `run:` steps only."""
+  commands: list[str] = []
+  lines = workflow_text.splitlines()
+  i = 0
+  while i < len(lines):
+    line = lines[i]
+    match = RUN_STEP_RE.match(line)
+    if match is None:
+      i += 1
+      continue
+
+    run_indent = len(match.group(1))
+    tail = match.group(2).strip()
+    if tail and not RUN_BLOCK_SCALAR_RE.fullmatch(tail):
+      line_parts = [tail]
+      i += 1
+      while i < len(lines):
+        candidate = lines[i]
+        stripped = candidate.lstrip(" ")
+        if not stripped:
+          break
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        line_parts.append(stripped)
+        i += 1
+      commands.append("\n".join(line_parts))
+      continue
+
+    i += 1
+    block_lines: list[str] = []
+    while i < len(lines):
+      candidate = lines[i]
+      stripped = candidate.lstrip(" ")
+      if stripped:
+        indent = len(candidate) - len(stripped)
+        if indent <= run_indent:
+          break
+        block_lines.append(stripped)
+      else:
+        block_lines.append("")
+      i += 1
+    commands.append("\n".join(block_lines))
+  return "\n".join(commands)


### PR DESCRIPTION
## Summary
- extract duplicated workflow `run:` parsing into `scripts/workflow_run_parser.py`
- update CI guard scripts to use the shared helper
- add `scripts/test_workflow_run_parser.py` to lock parser behavior

## Why
The same parser was duplicated across multiple CI guard scripts. Consolidating it removes drift risk and makes future parser fixes apply everywhere.

## Validation
- `python3 scripts/test_workflow_run_parser.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates workflow `run:` parsing logic used by CI guard scripts; main risk is unintended behavior change causing CI false positives/negatives, mitigated by new unit tests.
> 
> **Overview**
> Refactors CI guard scripts to use a shared `extract_workflow_run_text` helper instead of maintaining duplicated workflow `run:` parsing code in each check.
> 
> Adds `scripts/workflow_run_parser.py` plus `scripts/test_workflow_run_parser.py` to lock in parsing behavior for inline `run:` commands, block scalars, and ignoring non-`run` YAML fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f6ccc1d48c7602a92bf5b63f3a2163808094fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->