### PR TITLE
Add fail-closed CI guard for shell script execute bit

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Validate CI script timeout-wrapper coverage sync
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate CI script timeout-wrapper coverage sync" -- python3 scripts/check_ci_script_timeout_wrapper_coverage.py
 
+      - name: Validate shell script executable bit integrity
+        run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate shell script executable bit integrity" -- python3 scripts/check_shell_script_executable.py
+
       - name: Validate script-test pairing
         run: ./scripts/run_with_timeout.sh MORPHO_PARITY_TARGET_VALIDATE_TIMEOUT_SEC 300 "Validate script-test pairing" -- python3 scripts/check_script_test_pairs.py
 

--- a/scripts/check_shell_script_executable.py
+++ b/scripts/check_shell_script_executable.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail-closed check that all repository shell scripts are executable."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import stat
+import sys
+
+
+# Require owner execute bit because Git tracks executable files as mode 100755.
+REQUIRED_EXEC_BIT = stat.S_IXUSR
+
+
+def fail(msg: str) -> None:
+  print(f"shell-script-executable check failed: {msg}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def collect_shell_scripts(scripts_dir: pathlib.Path) -> list[pathlib.Path]:
+  return sorted(path for path in scripts_dir.glob("*.sh") if path.is_file())
+
+
+def find_non_executable_scripts(shell_scripts: list[pathlib.Path]) -> list[pathlib.Path]:
+  non_executable: list[pathlib.Path] = []
+  for path in shell_scripts:
+    mode = path.stat().st_mode
+    if mode & REQUIRED_EXEC_BIT == 0:
+      non_executable.append(path)
+  return non_executable
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Validate scripts/*.sh files are executable")
+  parser.add_argument(
+    "--scripts-dir",
+    type=pathlib.Path,
+    default=pathlib.Path("scripts"),
+    help="Path to scripts directory",
+  )
+  args = parser.parse_args()
+
+  shell_scripts = collect_shell_scripts(args.scripts_dir)
+  if not shell_scripts:
+    fail(f"{args.scripts_dir}: no shell scripts found")
+
+  non_executable = find_non_executable_scripts(shell_scripts)
+  if non_executable:
+    fail("non-executable shell scripts: " + ", ".join(path.name for path in non_executable))
+
+  print(f"shell-script-executable: scripts={len(shell_scripts)}")
+  print("shell-script-executable check: OK")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/test_check_shell_script_executable.py
+++ b/scripts/test_check_shell_script_executable.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for shell script executable-bit guard."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+
+import sys
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+  sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_shell_script_executable import (  # noqa: E402
+  collect_shell_scripts,
+  find_non_executable_scripts,
+  main,
+)
+
+
+class CheckShellScriptExecutableTests(unittest.TestCase):
+  def test_collect_shell_scripts(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      (scripts_dir / "alpha.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      (scripts_dir / "beta.py").write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+      self.assertEqual([path.name for path in collect_shell_scripts(scripts_dir)], ["alpha.sh"])
+
+  def test_find_non_executable_scripts(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      executable = scripts_dir / "alpha.sh"
+      non_executable = scripts_dir / "beta.sh"
+      executable.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      non_executable.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      executable.chmod(0o755)
+      non_executable.chmod(0o644)
+
+      self.assertEqual(
+        [path.name for path in find_non_executable_scripts([executable, non_executable])],
+        ["beta.sh"],
+      )
+
+  def test_main_passes_when_all_shell_scripts_are_executable(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      alpha = scripts_dir / "alpha.sh"
+      beta = scripts_dir / "beta.sh"
+      alpha.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      beta.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      alpha.chmod(0o755)
+      beta.chmod(0o755)
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_shell_script_executable.py",
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        self.assertEqual(main(), 0)
+      finally:
+        sys.argv = old_argv
+
+  def test_main_fails_when_shell_script_is_not_executable(self) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      scripts_dir = pathlib.Path(tmp_dir) / "scripts"
+      scripts_dir.mkdir()
+      alpha = scripts_dir / "alpha.sh"
+      beta = scripts_dir / "beta.sh"
+      alpha.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      beta.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+      alpha.chmod(0o755)
+      beta.chmod(0o644)
+
+      old_argv = sys.argv
+      try:
+        sys.argv = [
+          "check_shell_script_executable.py",
+          "--scripts-dir",
+          str(scripts_dir),
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+          main()
+        self.assertEqual(ctx.exception.code, 1)
+      finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
Adds a fail-closed CI guard that enforces executable permissions for `scripts/*.sh` files.

## Why
CI jobs execute shell scripts directly (for installs/checks/tests). If a script loses its executable bit, workflows can fail with `Permission denied`.

## Changes
- Add `scripts/check_shell_script_executable.py`
- Add unit tests in `scripts/test_check_shell_script_executable.py`
- Wire the check into `.github/workflows/verify.yml`

## Validation
- `python3 scripts/check_shell_script_executable.py`
- `python3 scripts/test_check_shell_script_executable.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `for t in scripts/test_*.sh; do "$t"; done`
- `python3 scripts/check_ci_check_coverage.py`
- `python3 scripts/check_ci_test_coverage.py`
- `python3 scripts/check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/check_script_test_pairs.py`
- `python3 scripts/check_ci_timeout_defaults.py`

Closes #111.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to CI validation and a new Python check script; the main impact is that CI will now fail if any `scripts/*.sh` loses its executable bit (or if none exist).
> 
> **Overview**
> **Adds a new CI guard** that validates every `scripts/*.sh` file is executable (owner execute bit set) and fails the workflow if any script is not.
> 
> Wires the check into `.github/workflows/verify.yml` and adds `scripts/test_check_shell_script_executable.py` to cover collection, detection, and pass/fail behavior of `scripts/check_shell_script_executable.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 407beee15196a6ad4f058093f94a8ac0eee054f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->