### PR TITLE
Harden CI timeout guards for interpreter-invoked scripts

### DIFF
--- a/scripts/check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_script_timeout_wrapper_coverage.py
@@ -11,11 +11,12 @@ import sys
 from workflow_run_parser import extract_workflow_run_text
 
 WORKFLOW_SCRIPT_REF_RE = re.compile(
-  r"\b(?:python3\s+)?(?:\./)?scripts/([A-Za-z0-9_]+\.(?:py|sh))\b"
+  r"\b(?:(?:python3|python|bash|sh)\s+|env\s+(?:python3|python|bash|sh)\s+)?"
+  r"(?:\./)?scripts/([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 RUN_WITH_TIMEOUT_TARGET_RE = re.compile(
   r"(?:\./|\.\./)?scripts/run_with_timeout\.sh[^\n]*[ \t]+--[ \t]+"
-  r"(?:(?:python3[ \t]+)(?:\./)?scripts/|(?:\./)?scripts/)"
+  r"(?:(?:(?:python3|python|bash|sh)[ \t]+|env[ \t]+(?:python3|python|bash|sh)[ \t]+)?(?:\./)?scripts/)"
   r"([A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")

--- a/scripts/check_ci_timeout_wrapper_coverage.py
+++ b/scripts/check_ci_timeout_wrapper_coverage.py
@@ -12,7 +12,8 @@ from workflow_run_parser import extract_workflow_run_text
 
 WORKFLOW_CHECK_REF_RE = re.compile(r"\bscripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b")
 RUN_WITH_TIMEOUT_STEP_RE = re.compile(
-  r"run_with_timeout\.sh[^\n]*[ \t]+(?:--[ \t]+)?(?:python3[ \t]+)?"
+  r"run_with_timeout\.sh[^\n]*[ \t]+(?:--[ \t]+)?"
+  r"(?:(?:python3|python|bash|sh)[ \t]+|env[ \t]+(?:python3|python|bash|sh)[ \t]+)?"
   r"(?:\./)?scripts/(check_[A-Za-z0-9_]+\.(?:py|sh))\b"
 )
 LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")

--- a/scripts/test_check_ci_script_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_script_timeout_wrapper_coverage.py
@@ -28,12 +28,20 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
       [
         "run: ./scripts/install_lean.sh",
         "run: python3 scripts/check_alpha.py",
+        "run: bash scripts/install_foundry.sh",
+        "run: env sh scripts/install_solc.sh",
         "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_solc.sh 0.8.28",
       ]
     )
     self.assertEqual(
       collect_workflow_script_references(workflow_text),
-      {"install_lean.sh", "check_alpha.py", "run_with_timeout.sh", "install_solc.sh"},
+      {
+        "install_lean.sh",
+        "check_alpha.py",
+        "install_foundry.sh",
+        "install_solc.sh",
+        "run_with_timeout.sh",
+      },
     )
 
   def test_collect_workflow_script_references_ignores_non_run_references(self) -> None:
@@ -52,11 +60,13 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
         "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
         "run: ./scripts/run_with_timeout.sh M 1 d -- ./scripts/install_solc.sh 0.8.28",
         "run: ../scripts/run_with_timeout.sh M 1 d -- ./scripts/install_lean.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- bash scripts/install_foundry.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 d -- env sh scripts/install_solc.sh",
       ]
     )
     self.assertEqual(
       collect_wrapped_script_targets(workflow_text),
-      {"check_alpha.py", "install_solc.sh", "install_lean.sh"},
+      {"check_alpha.py", "install_solc.sh", "install_lean.sh", "install_foundry.sh"},
     )
 
   def test_collect_wrapped_script_targets_does_not_cross_lines(self) -> None:
@@ -126,7 +136,7 @@ class CheckCiScriptTimeoutWrapperCoverageTests(unittest.TestCase):
   def test_main_fails_on_unwrapped_script(self) -> None:
     workflow_text = "\n".join(
       [
-        "run: ./scripts/install_lean.sh",
+        "run: bash scripts/install_lean.sh",
         "run: ./scripts/run_with_timeout.sh M 1 d -- python3 scripts/check_alpha.py",
       ]
     )

--- a/scripts/test_check_ci_timeout_wrapper_coverage.py
+++ b/scripts/test_check_ci_timeout_wrapper_coverage.py
@@ -50,11 +50,19 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
         "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_alpha.py",
         "run: ./scripts/run_with_timeout.sh M 1 desc -- python3 scripts/check_beta.py --strict",
         "run: ./scripts/run_with_timeout.sh M 1 desc -- ./scripts/check_gamma.sh --require lean",
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- bash scripts/check_delta.sh",
+        "run: ./scripts/run_with_timeout.sh M 1 desc -- env sh scripts/check_epsilon.sh",
       ]
     )
     self.assertEqual(
       collect_wrapped_check_scripts(workflow_text),
-      {"check_alpha.py", "check_beta.py", "check_gamma.sh"},
+      {
+        "check_alpha.py",
+        "check_beta.py",
+        "check_gamma.sh",
+        "check_delta.sh",
+        "check_epsilon.sh",
+      },
     )
 
   def test_collect_wrapped_check_scripts_does_not_cross_lines(self) -> None:
@@ -98,7 +106,7 @@ class CheckCiTimeoutWrapperCoverageTests(unittest.TestCase):
     workflow_text = "\n".join(
       [
         "run: ./scripts/run_with_timeout.sh M 1 check -- python3 scripts/check_alpha.py",
-        "run: ./scripts/check_beta.sh --require solc",
+        "run: bash scripts/check_beta.sh --require solc",
       ]
     )
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- extend timeout-wrapper coverage regexes to detect interpreter-prefixed script execution forms (`bash`, `sh`, `python`, and `env ...`)
- ensure wrapped-target detection for `check_*.{py,sh}` and general `scripts/*.{py,sh}` remains fail-closed when interpreter prefixes are used
- add regression tests covering wrapped/unwrapped interpreter-invoked paths

## Validation
- `python3 scripts/test_check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/test_check_ci_script_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_timeout_wrapper_coverage.py`
- `python3 scripts/check_ci_script_timeout_wrapper_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Regex-based detection changes can cause CI to newly fail (or miss) script invocations if patterns are too broad/narrow. Added tests reduce but don’t eliminate the risk of false positives/negatives across real workflow command variants.
> 
> **Overview**
> Tightens the CI “fail-closed” guards that ensure `scripts/*.py|.sh` and `check_*.py|.sh` invocations are wrapped by `run_with_timeout.sh` by expanding the regex matchers to handle interpreter-prefixed forms like `bash`, `sh`, `python`, and `env …`.
> 
> Updates unit tests to cover these interpreter-invoked wrapped and unwrapped cases, ensuring the coverage checks still correctly flag unwrapped executions and accept wrapped targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce16e856752547434157849049b99b67838e67c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->