### PR TITLE
Make partial-phrasing counterexample well-formed; prove repay/liquidate index non-growth

### DIFF
--- a/Morpho/Proofs/Property1.lean
+++ b/Morpho/Proofs/Property1.lean
@@ -32,6 +32,41 @@ open Morpho.Proofs.HealthModel.HealthState
 open Morpho.Proofs.Arith
 open Morpho.Proofs.Env
 
+/-- `a * b ≤ d * ⌈a·b/d⌉` for `d > 0`: ceiling division never undershoots. -/
+theorem le_mul_mulDivUp (a b d : Nat) (hd : 0 < d) : a * b ≤ d * mulDivUp a b d := by
+  unfold mulDivUp
+  have h := Nat.div_add_mod (a * b + (d - 1)) d
+  have hmod : (a * b + (d - 1)) % d < d := Nat.mod_lt _ hd
+  omega
+
+/-- A repayment or liquidation by *any* account lowers the market totals by
+    `repaidShares` shares and the matching `repaidAssets`, where the asset side is
+    the share-to-asset conversion *rounded up* (the `mulDivUp` at the `borrowed`
+    formula, Morpho/Contract.lean:881). Because that conversion rounds up, the
+    borrow index `(totBorrowAssets+1)/(totBorrowShares+VIRTUAL)` cannot grow. This
+    discharges `borrowIndexNoGrow` for a third party's repay/liquidate *without*
+    appealing to no-accrual: only `_accrueInterest` can actually grow the index. -/
+theorem borrowIndexNoGrow_of_repay {s s' : HealthState} (repaidShares : Nat)
+    (hsh : s'.totBorrowShares + repaidShares = s.totBorrowShares)
+    (hass : s'.totBorrowAssets
+              + mulDivUp repaidShares (s.totBorrowAssets + VIRTUAL_ASSETS)
+                  (s.totBorrowShares + VIRTUAL_SHARES)
+            = s.totBorrowAssets) :
+    borrowIndexNoGrow s s' := by
+  unfold borrowIndexNoGrow
+  have hb_pos : 0 < s.totBorrowShares + VIRTUAL_SHARES := by
+    have : 0 < VIRTUAL_SHARES := by decide
+    omega
+  set rA := mulDivUp repaidShares (s.totBorrowAssets + VIRTUAL_ASSETS)
+              (s.totBorrowShares + VIRTUAL_SHARES) with hrA
+  have hkey : repaidShares * (s.totBorrowAssets + VIRTUAL_ASSETS)
+                ≤ (s.totBorrowShares + VIRTUAL_SHARES) * rA := by
+    rw [hrA]; exact le_mul_mulDivUp _ _ _ hb_pos
+  have e1 : s.totBorrowAssets = s'.totBorrowAssets + rA := by omega
+  have e2 : s.totBorrowShares = s'.totBorrowShares + repaidShares := by omega
+  rw [e1, e2] at hkey ⊢
+  nlinarith [hkey]
+
 /-- The watched account's storage changed monotonically in the health-favourable
     direction, at constant price/LLTV, with a non-growing borrow index. -/
 structure MonotoneFor (s s' : HealthState) : Prop where

--- a/Morpho/Proofs/Property1.lean
+++ b/Morpho/Proofs/Property1.lean
@@ -44,8 +44,11 @@ theorem le_mul_mulDivUp (a b d : Nat) (hd : 0 < d) : a * b ≤ d * mulDivUp a b 
     the share-to-asset conversion *rounded up* (the `mulDivUp` at the `borrowed`
     formula, Morpho/Contract.lean:881). Because that conversion rounds up, the
     borrow index `(totBorrowAssets+1)/(totBorrowShares+VIRTUAL)` cannot grow. This
-    discharges `borrowIndexNoGrow` for a third party's repay/liquidate *without*
-    appealing to no-accrual: only `_accrueInterest` can actually grow the index. -/
+    *provides* a `borrowIndexNoGrow` witness for a third party's repay/liquidate
+    from the rounding direction alone, with no appeal to no-accrual. It is
+    standalone infrastructure: `no_operation_breaks_health` still takes the index
+    condition as a `MonotoneFor` field, so consuming this witness in the headline
+    proof awaits the Refinement extraction layer (see `Refinement.lean`). -/
 theorem borrowIndexNoGrow_of_repay {s s' : HealthState} (repaidShares : Nat)
     (hsh : s'.totBorrowShares + repaidShares = s.totBorrowShares)
     (hass : s'.totBorrowAssets

--- a/Morpho/Proofs/Property2.lean
+++ b/Morpho/Proofs/Property2.lean
@@ -124,11 +124,14 @@ theorem healthy_of_no_debt {s : HealthState} (h : s.borrowShares = 0) : healthy 
 /-- The model's `liquidate` does not grow the borrow index. This connects the
     generic `borrowIndexNoGrow_of_repay` to the concrete `liquidate` field writes:
     a liquidation (by the borrower or any third party) lowers `totBorrowShares` by
-    `repaidShares` and `totBorrowAssets` by the rounded-up `repaidAssets`, so for a
-    *watched* account in the same market the index condition of `MonotoneFor` holds
-    by the rounding direction, with no appeal to `NoAccrual`. The hypotheses are the
-    well-formedness facts the contract maintains: you cannot repay more shares than
-    the market holds, nor more assets than it owes. -/
+    `repaidShares` and `totBorrowAssets` by the rounded-up `repaidAssets`, so it
+    supplies the `borrowIndexNoGrow` field that `MonotoneFor` requires for a watched
+    account in the same market, by the rounding direction alone rather than from
+    `NoAccrual`. Like `borrowIndexNoGrow_of_repay`, this is not yet consumed by the
+    headline `no_operation_breaks_health`; it is the witness the extraction layer
+    will plug into the other-account case. The hypotheses are the well-formedness
+    facts the contract maintains: you cannot repay more shares than the market
+    holds, nor more assets than it owes. -/
 theorem liquidate_borrowIndexNoGrow (s : HealthState) (repaidShares seized : Nat)
     (hsh : repaidShares ≤ s.totBorrowShares)
     (hass : mulDivUp repaidShares (s.totBorrowAssets + VIRTUAL_ASSETS)

--- a/Morpho/Proofs/Property2.lean
+++ b/Morpho/Proofs/Property2.lean
@@ -201,10 +201,13 @@ theorem sharp_property2 (s : HealthState) (hltv : ltvBelowInvLif s) :
 
 /-- A concrete witness that the *partial* phrasing fails: an unhealthy position with
     `borrowShares = 1` satisfying `LTV < 1/LIF`. `borrowed = 100`, `maxBorrow = 96`
-    (so unhealthy), and `borrowed ⋅ LIF ≈ 106.4e18 < 120e18` (so `ltvBelowInvLif`). -/
+    (so unhealthy), and `borrowed ⋅ LIF ≈ 106.4e18 < 120e18` (so `ltvBelowInvLif`).
+    The market totals are well-formed (`borrowShares ≤ totBorrowShares`, so the
+    position does not hold more shares than the whole market exists with), to show
+    the failure is not an artifact of an unreachable state. -/
 def partialCounterexample : HealthState :=
   { borrowShares := 1, collateral := 120, totBorrowAssets := 99999999,
-    totBorrowShares := 0, lltv := 800000000000000000, price := ORACLE_PRICE_SCALE }
+    totBorrowShares := 1, lltv := 800000000000000000, price := ORACLE_PRICE_SCALE }
 
 /-- **Counterexample to the partial phrasing.** `partialCounterexample` satisfies
     the `1/LIF` hypothesis and is unhealthy, yet no *strict-partial* liquidation

--- a/Morpho/Proofs/Property2.lean
+++ b/Morpho/Proofs/Property2.lean
@@ -121,6 +121,23 @@ def liquidate (s : HealthState) (repaidShares seized : Nat) : HealthState :=
 theorem healthy_of_no_debt {s : HealthState} (h : s.borrowShares = 0) : healthy s :=
   Or.inl h
 
+/-- The model's `liquidate` does not grow the borrow index. This connects the
+    generic `borrowIndexNoGrow_of_repay` to the concrete `liquidate` field writes:
+    a liquidation (by the borrower or any third party) lowers `totBorrowShares` by
+    `repaidShares` and `totBorrowAssets` by the rounded-up `repaidAssets`, so for a
+    *watched* account in the same market the index condition of `MonotoneFor` holds
+    by the rounding direction, with no appeal to `NoAccrual`. The hypotheses are the
+    well-formedness facts the contract maintains: you cannot repay more shares than
+    the market holds, nor more assets than it owes. -/
+theorem liquidate_borrowIndexNoGrow (s : HealthState) (repaidShares seized : Nat)
+    (hsh : repaidShares ≤ s.totBorrowShares)
+    (hass : mulDivUp repaidShares (s.totBorrowAssets + VIRTUAL_ASSETS)
+              (s.totBorrowShares + VIRTUAL_SHARES) ≤ s.totBorrowAssets) :
+    borrowIndexNoGrow s (liquidate s repaidShares seized) := by
+  apply Morpho.Proofs.Property1.borrowIndexNoGrow_of_repay repaidShares
+  · simp only [liquidate]; omega
+  · simp only [liquidate]; omega
+
 /--
   **Property 2 (existence).** Repaying the borrower's entire share balance drives
   `borrowShares` to 0, which is healthy by the zero-debt branch — so a liquidation


### PR DESCRIPTION
## Summary
- Make `partialCounterexample` (Property2.lean) a **well-formed market state**: it previously set `totBorrowShares := 0` while holding `borrowShares := 1`, i.e. a position owning more shares than the entire market — an unreachable state. Set `totBorrowShares := 1` so the counterexample to the partial-liquidation phrasing stands on a reachable state.
- Add `le_mul_mulDivUp` and `borrowIndexNoGrow_of_repay` (Property1.lean): a third-party repay/liquidate cannot grow the shared borrow index, proved from rounding direction alone (no `NoAccrual` appeal).
- Add `liquidate_borrowIndexNoGrow` (Property2.lean) connecting that lemma to the concrete `liquidate`.
- Docstrings state honestly that these index lemmas are standalone infrastructure, not yet consumed by the headline `no_operation_breaks_health`.

## Test plan
- [x] `lake build Morpho.Proofs` succeeds (3057/3057) locally
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean formal proofs and documentation; no contract or runtime behavior is modified.
> 
> **Overview**
> **Property1** gains **`le_mul_mulDivUp`** (ceiling division never undershoots) and **`borrowIndexNoGrow_of_repay`**, showing that any repay/liquidate that removes shares and the matching **`mulDivUp`** repaid assets cannot increase the shared borrow index—without assuming no accrual. Docstrings note this is infrastructure for a future Refinement layer, not yet wired into **`no_operation_breaks_health`**.
> 
> **Property2** adds **`liquidate_borrowIndexNoGrow`**, instantiating that lemma on the concrete **`liquidate`** model under standard well-formedness bounds. The **`partialCounterexample`** for why partial liquidation is the wrong invariant is corrected from **`totBorrowShares := 0`** to **`1`**, so **`borrowShares = 1`** no longer exceeds total market shares; comments are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d132fab27815b711e2a592826f2672a2decdba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->