### PR TITLE
Prove liquidate pre-state unhealthiness

### DIFF
--- a/Morpho/Proofs/Disciplines.lean
+++ b/Morpho/Proofs/Disciplines.lean
@@ -2,8 +2,8 @@ import Morpho.Proofs.FramePreserve
 import Morpho.Proofs.Env
 import Morpho.Proofs.Projection
 import Morpho.Proofs.HealthFaithful
+import Morpho.Proofs.PackedWordLemmas
 import Morpho.Contract
-import Contracts.PackedWordLemmas
 import Mathlib.Data.Nat.Bitwise
 
 namespace Morpho.Proofs.Disciplines
@@ -1248,6 +1248,15 @@ def LocalNoOverflow (P : Position) (cs : ContractState) : Prop :=
 def LocalNoOverflowFor (P : Position) : Prop :=
   ∀ cs, LocalNoOverflow P cs
 
+/-- No-accrual contract-side discipline for the watched market: the embedded
+    `_accrueInterest` helper leaves the call state unchanged. This is the
+    generated-body counterpart of the proof model's "without considering debt
+    accrual" assumption. -/
+def AccrueInterestIdentityFor (P : Position) : Prop :=
+  ∀ cs accrued cs',
+    (_accrueInterest P.mp P.id).run cs = ContractResult.success accrued cs' →
+      cs' = cs
+
 theorem noOverflow_of_localNoOverflow (P : Position) (cs : ContractState)
     (hlocal : LocalNoOverflow P cs) :
     NoOverflow P.mp P.id P.account P.price cs := by
@@ -1408,6 +1417,81 @@ theorem liquidate_guardUnhealthy_afterAccrue_price (P : Position)
     simpa [oraclePriceRead] using h
   rw [← hp]
   rw [Contract.run, hraw]
+
+set_option maxHeartbeats 4000000 in
+set_option maxRecDepth 100000 in
+theorem liquidate_preStateUnhealthy_of_accrueInterest_identity (P : Position)
+    (hid : MarketIdAligned P) (hprice : OraclePriceAligned P)
+    (hnoAccrual : AccrueInterestIdentityFor P) :
+    ∀ seized repaid data out cs cs',
+      (liquidate P.mp P.account seized repaid data).run cs =
+          ContractResult.success out cs' →
+        ∃ csHealth,
+          (_isHealthyWithPrice P.mp P.id P.account P.price).run cs =
+            ContractResult.success false csHealth := by
+  intro seized repaid data out cs cs' hrun
+  have hbody := run_eq_of_success hrun
+  simp only [liquidate, Bind.bind, Pure.pure,
+      Morpho.Contract.Morpho.structMember,
+      Morpho.Contract.Morpho.structMember2,
+      Morpho.Contract.Morpho.setStructMember,
+      Morpho.Contract.Morpho.setStructMember2,
+      Contracts.emit, Contracts.EventArg.toWord, List.mapM_cons, List.mapM_nil,
+      Verity.Contract.bind_pure_left,
+      Bool.and_eq_true, beq_iff_eq, String.reduceEq,
+      and_true, and_false, if_true, if_false] at hbody
+  simp only [Verity.bind, Contracts.ecmEnvRead, Contracts.structMemberAt,
+    Verity.require] at hbody
+  have hidEq := hid cs
+  simp only [marketIdRead] at hidEq
+  rw [hidEq] at hbody
+  split at hbody
+  · next currentLastUpdate stLast hlast =>
+    have hstLast : stLast = cs := by
+      split at hlast
+      · cases hlast
+        rfl
+      · cases hlast
+    split at hbody
+    · next _ stCreated hcreated =>
+      have hstCreated : stCreated = stLast := by
+        split at hcreated
+        · cases hcreated
+          rfl
+        · cases hcreated
+      split at hbody
+      · next accrued stPostAccrue hacc =>
+        have haccRun :
+            (_accrueInterest P.mp P.id).run stCreated =
+              ContractResult.success accrued stPostAccrue := by
+          unfold Contract.run
+          simp [hacc]
+        have hsameAccrue : stPostAccrue = stCreated :=
+          hnoAccrual stCreated accrued stPostAccrue haccRun
+        have hpre : stPostAccrue = cs := by
+          rw [hsameAccrue, hstCreated, hstLast]
+        split at hbody
+        · next healthBool stHealth hhealth =>
+          split at hbody
+          · next _ stReqHealthy hreqHealthy =>
+            cases healthBool
+            · have hpriceEq : oraclePriceRead P.mp stPostAccrue = P.price := by
+                have h := hprice stPostAccrue 0xa035b1fe
+                simpa [oraclePriceRead] using h
+              have hhealthPrice :
+                  _isHealthyWithPrice P.mp P.id P.account P.price stPostAccrue =
+                    ContractResult.success false stHealth := by
+                rw [← hpriceEq]
+                simpa [oraclePriceRead] using hhealth
+              refine ⟨stHealth, ?_⟩
+              rw [← hpre]
+              simp [Contract.run, hhealthPrice]
+            · exact False.elim (by cases hreqHealthy)
+          · exact False.elim (by cases hbody)
+        · exact False.elim (by cases hbody)
+      · exact False.elim (by cases hbody)
+    · exact False.elim (by cases hbody)
+  · exact False.elim (by cases hbody)
 
 set_option maxRecDepth 100000 in
 theorem healthy_of_isHealthy_success (P : Position) (hprice : OraclePriceAligned P)

--- a/Morpho/Proofs/Disciplines.lean
+++ b/Morpho/Proofs/Disciplines.lean
@@ -1224,9 +1224,6 @@ def OraclePriceAligned (P : Position) : Prop :=
     cs.ecmResults (Compiler.Modules.Oracle.oracleReadUint256Module "_ecm" selector 0).name
       [addressToWord P.mp.oracle] 0 = P.price
 
-def NoOverflowFor (P : Position) : Prop :=
-  ∀ cs, NoOverflow P.mp P.id P.account P.price cs
-
 /-- The remaining local health-arithmetic bound: quoting the watched account's
     collateral at the oracle price, then applying LLTV, fits in one `uint256`
     word. Borrow-side add and share-conversion bounds are reconstructed from
@@ -1277,11 +1274,6 @@ theorem noOverflow_of_localNoOverflow (P : Position) (cs : ContractState)
       native_decide
     omega
   exact ⟨h_addA, h_addS, hlocal.1, hlocal.2⟩
-
-theorem noOverflowFor_of_localNoOverflowFor (P : Position)
-    (h : LocalNoOverflowFor P) : NoOverflowFor P := by
-  intro cs
-  exact noOverflow_of_localNoOverflow P cs (h cs)
 
 /-- The projected field discipline a successful step guarantees for the watched
     position: `lltv` fixed, collateral does not fall, borrow shares do not rise. -/

--- a/Morpho/Proofs/HealthFaithful.lean
+++ b/Morpho/Proofs/HealthFaithful.lean
@@ -4,8 +4,8 @@
 -/
 
 import Morpho.Proofs.Projection
+import Morpho.Proofs.PackedWordLemmas
 import Verity.Proofs.Stdlib.Math
-import Contracts.PackedWordLemmas
 import Mathlib.Data.Nat.Bitwise
 
 namespace Morpho.Proofs.HealthFaithful

--- a/Morpho/Proofs/PackedWordLemmas.lean
+++ b/Morpho/Proofs/PackedWordLemmas.lean
@@ -1,0 +1,174 @@
+import Contracts.Common
+
+namespace Contracts
+
+open Verity.Core
+
+/-- Public proof-side copy of Verity's packed-word mask helper. The executable
+    helpers in `Contracts.Common` use the same body internally but keep the
+    helper private. -/
+def packedMask (width : Nat) : Nat :=
+  2 ^ width - 1
+
+/-- Public proof-side copy of Verity's packed-word decoder. -/
+def decodePackedWord (word : Uint256) (offset width : Nat) : Uint256 :=
+  Uint256.and (Uint256.shr offset word) (packedMask width)
+
+/-- Public proof-side copy of Verity's packed-word encoder. -/
+def encodePackedWord (current value : Uint256) (offset width : Nat) : Uint256 :=
+  let mask := packedMask width
+  let shiftedMask := Uint256.shl offset mask
+  let packedValue := Uint256.and value mask
+  Uint256.or (Uint256.and current (Uint256.not shiftedMask)) (Uint256.shl offset packedValue)
+
+namespace PackedWord
+
+private lemma ofNat_val (n : Nat) : (Uint256.ofNat n).val = n % 2 ^ 256 := rfl
+
+private lemma testBit_mod (x i : Nat) :
+    Nat.testBit (x % 2 ^ 256) i = (decide (i < 256) && Nat.testBit x i) :=
+  Nat.testBit_mod_two_pow x 256 i
+
+private lemma testBit_ofNat (x i : Nat) :
+    Nat.testBit (Uint256.ofNat x).val i = (decide (i < 256) && Nat.testBit x i) := by
+  rw [ofNat_val]; exact testBit_mod x i
+
+private lemma testBit_and (a b : Uint256) (i : Nat) :
+    Nat.testBit (Uint256.and a b).val i
+      = (decide (i < 256) && (Nat.testBit a.val i && Nat.testBit b.val i)) := by
+  show Nat.testBit (Uint256.ofNat (a.val &&& b.val)).val i = _
+  rw [testBit_ofNat, Nat.testBit_and]
+
+private lemma testBit_or (a b : Uint256) (i : Nat) :
+    Nat.testBit (Uint256.or a b).val i
+      = (decide (i < 256) && (Nat.testBit a.val i || Nat.testBit b.val i)) := by
+  show Nat.testBit (Uint256.ofNat (a.val ||| b.val)).val i = _
+  rw [testBit_ofNat, Nat.testBit_or]
+
+private lemma testBit_shl (s v : Uint256) (i : Nat) :
+    Nat.testBit (Uint256.shl s v).val i
+      = (decide (i < 256) && (decide (s.val ≤ i) && Nat.testBit v.val (i - s.val))) := by
+  show Nat.testBit (Uint256.ofNat (v.val <<< s.val)).val i = _
+  rw [testBit_ofNat, Nat.testBit_shiftLeft]
+
+private lemma testBit_shr (s v : Uint256) (i : Nat) :
+    Nat.testBit (Uint256.shr s v).val i
+      = (decide (i < 256) && Nat.testBit v.val (s.val + i)) := by
+  show Nat.testBit (Uint256.ofNat (v.val >>> s.val)).val i = _
+  rw [testBit_ofNat, Nat.testBit_shiftRight]
+
+private lemma val_not (a : Uint256) :
+    (Uint256.not a).val = 2 ^ 256 - (a.val + 1) := by
+  show (MAX_UINT256 - a.val) % Uint256.modulus = 2 ^ 256 - (a.val + 1)
+  have ha : a.val < 2 ^ 256 := a.isLt
+  have heq : MAX_UINT256 - a.val = 2 ^ 256 - (a.val + 1) := by
+    show 2 ^ 256 - 1 - a.val = 2 ^ 256 - (a.val + 1)
+    omega
+  rw [heq]
+  apply Nat.mod_eq_of_lt
+  show 2 ^ 256 - (a.val + 1) < 2 ^ 256
+  have hpos : 0 < 2 ^ 256 := Nat.two_pow_pos 256
+  omega
+
+private lemma testBit_not (a : Uint256) (i : Nat) :
+    Nat.testBit (Uint256.not a).val i = (decide (i < 256) && !Nat.testBit a.val i) := by
+  rw [val_not]
+  exact Nat.testBit_two_pow_sub_succ a.isLt i
+
+private lemma testBit_val_of_ge_256 (a : Uint256) {i : Nat} (hi : 256 ≤ i) :
+    Nat.testBit a.val i = false := by
+  apply Nat.testBit_lt_two_pow
+  exact lt_of_lt_of_le a.isLt (Nat.pow_le_pow_right (by decide) hi)
+
+private lemma offset_coe_val {offset : Nat} (h : offset ≤ 256) :
+    (Uint256.ofNat offset).val = offset := by
+  rw [ofNat_val]
+  apply Nat.mod_eq_of_lt
+  have h256 : (256 : Nat) < 2 ^ 256 := by decide
+  omega
+
+private lemma testBit_packedMask (w i : Nat) :
+    Nat.testBit (packedMask w) i = decide (i < w) := by
+  unfold packedMask; exact Nat.testBit_two_pow_sub_one w i
+
+private lemma testBit_packedMask_coe (w i : Nat) :
+    Nat.testBit (Uint256.ofNat (packedMask w)).val i
+      = (decide (i < 256) && decide (i < w)) := by
+  rw [testBit_ofNat, testBit_packedMask]
+
+theorem decode_encode_eq (current value : Uint256) (offset width : Nat)
+    (hoff : offset + width ≤ 256) (hval : value.val < 2 ^ width) :
+    decodePackedWord (encodePackedWord current value offset width) offset width = value := by
+  apply Uint256.ext
+  apply Nat.eq_of_testBit_eq
+  intro j
+  have hoff_le : offset ≤ 256 := Nat.le_of_add_right_le hoff
+  have hocoe : (Uint256.ofNat offset).val = offset := offset_coe_val hoff_le
+  show Nat.testBit
+    (Uint256.and
+      (Uint256.shr (↑offset) (Uint256.or
+        (Uint256.and current
+          (Uint256.not (Uint256.shl (↑offset) (↑(packedMask width)))))
+        (Uint256.shl (↑offset) (Uint256.and value (↑(packedMask width))))))
+      (↑(packedMask width))).val j = Nat.testBit value.val j
+  simp only [testBit_and, testBit_shr, testBit_or, testBit_not, testBit_shl,
+             testBit_packedMask_coe, hocoe]
+  by_cases hj256 : j < 256
+  · by_cases hjw : j < width
+    · have hofj256 : offset + j < 256 := by omega
+      have hofj_ge : offset ≤ offset + j := Nat.le_add_right _ _
+      have hsub : (offset + j) - offset = j := by omega
+      simp only [hj256, hjw, hofj256, hofj_ge, hsub, decide_true, Bool.true_and, Bool.and_true]
+      cases hb : Nat.testBit value.val j <;> simp
+    · push_neg at hjw
+      have hval_bit : Nat.testBit value.val j = false := by
+        apply Nat.testBit_lt_two_pow
+        exact lt_of_lt_of_le hval (Nat.pow_le_pow_right (by decide) hjw)
+      have hdw : decide (j < width) = false := by simp [Nat.not_lt.mpr hjw]
+      simp [hval_bit, hdw]
+  · push_neg at hj256
+    have hval_bit : Nat.testBit value.val j = false := testBit_val_of_ge_256 value hj256
+    have hd256 : decide (j < 256) = false := by simp [Nat.not_lt.mpr hj256]
+    simp [hval_bit, hd256]
+
+theorem decode_encode_disjoint (current value : Uint256) (o1 w1 o2 w2 : Nat)
+    (hbound1 : o1 + w1 ≤ 256) (hbound2 : o2 + w2 ≤ 256)
+    (hdisj : o1 + w1 ≤ o2 ∨ o2 + w2 ≤ o1) :
+    decodePackedWord (encodePackedWord current value o2 w2) o1 w1
+      = decodePackedWord current o1 w1 := by
+  apply Uint256.ext
+  apply Nat.eq_of_testBit_eq
+  intro j
+  have ho1_le : o1 ≤ 256 := Nat.le_of_add_right_le hbound1
+  have ho2_le : o2 ≤ 256 := Nat.le_of_add_right_le hbound2
+  have ho1coe : (Uint256.ofNat o1).val = o1 := offset_coe_val ho1_le
+  have ho2coe : (Uint256.ofNat o2).val = o2 := offset_coe_val ho2_le
+  show Nat.testBit
+    (Uint256.and
+      (Uint256.shr (↑o1) (Uint256.or
+        (Uint256.and current
+          (Uint256.not (Uint256.shl (↑o2) (↑(packedMask w2)))))
+        (Uint256.shl (↑o2) (Uint256.and value (↑(packedMask w2))))))
+      (↑(packedMask w1))).val j =
+    Nat.testBit (Uint256.and (Uint256.shr (↑o1) current) (↑(packedMask w1))).val j
+  simp only [testBit_and, testBit_shr, testBit_or, testBit_not, testBit_shl,
+             testBit_packedMask_coe, ho1coe, ho2coe]
+  by_cases hj256 : j < 256
+  · by_cases hjw1 : j < w1
+    · have ho1j256 : o1 + j < 256 := by omega
+      rcases hdisj with h | h
+      · have hf : decide (o2 ≤ o1 + j) = false := by
+          simp only [decide_eq_false_iff_not, Nat.not_le]; omega
+        simp [hj256, hjw1, ho1j256, hf]
+      · have hf : decide (o1 + j - o2 < w2) = false := by
+          simp only [decide_eq_false_iff_not, Nat.not_lt]; omega
+        simp [hj256, hjw1, ho1j256, hf]
+    · have hdw1 : decide (j < w1) = false := by simp [hjw1]
+      simp [hdw1]
+  · push_neg at hj256
+    have hd256 : decide (j < 256) = false := by simp [Nat.not_lt.mpr hj256]
+    simp [hd256]
+
+end PackedWord
+
+end Contracts

--- a/Morpho/Proofs/Refinement.lean
+++ b/Morpho/Proofs/Refinement.lean
@@ -7,16 +7,15 @@
   `OpShape` cases of `Property1` after projection. We state those obligations here
   as explicit `Prop`s.
 
-  These are deliberately *specifications*, not `sorry`-backed theorems. The
-  abstract `modelStep` section below discharges them at the hand-transcribed model
-  level. The `Contract` namespace at the end of this file then closes the gap to
-  the generated code: there each entrypoint's `Step` is the *real* executable
+  These propositions are specifications with proof terms below. The abstract
+  `modelStep` section discharges them at the hand-transcribed model level. The
+  `Contract` namespace at the end of this file then closes the gap to the
+  generated code: there each entrypoint's `Step` is the *real* executable
   `verity_contract Morpho` body, run to success and projected through
   `Projection.lean`, and the classified shape is discharged from named boundary
   obligations (field locality, the `require(_isHealthy)` guards, arithmetic
-  faithfulness) rather than from a parallel model. This is not a second source of
-  truth: the body is the contract's own. The residual step-to-EVM-bytecode link
-  stays empirical, guarded by the differential tests.
+  faithfulness). The residual step-to-EVM-bytecode link stays empirical, guarded
+  by the differential tests.
 
   Stating the obligations this way keeps the boundary honest: the model cannot
   silently diverge from the contract, because the gap is named and enumerated.
@@ -214,8 +213,8 @@ theorem property1_holds (e : Entrypoint) (hasm : Assumptions (modelStep e))
     — a successful run lands in a healthy post-state, from the final
     `require(_isHealthy)`;
   - `liquidate`: `GuardUnhealthy` proves its generated
-    `require(!_isHealthy)` guard fired after `_accrueInterest`; the remaining
-    pre-state refinement bridge is named separately from that structural fact.
+    `require(!_isHealthy)` guard fired after `_accrueInterest`, and the
+    no-accrual bridge replays that guard on the original projected pre-state.
 -/
 namespace Contract
 

--- a/Morpho/Proofs/Refinement.lean
+++ b/Morpho/Proofs/Refinement.lean
@@ -281,12 +281,12 @@ theorem refines_withdrawCollateral (P : Position)
   `liquidate`. The step is the real generated body run to success and projected
   at the watched position. Its classified shape is `¬ healthy s`: a liquidation
   is only the right operation on an already-unhealthy position. This is
-  discharged from a proved structural guard extraction plus an explicit pre-state
-  health bridge. `GuardUnhealthy` is the contract's own
+  discharged from a proved structural guard extraction plus the no-accrual
+  contract-side discipline. `GuardUnhealthy` is the contract's own
   `require(!_isHealthy)`: a successful run forces the post-accrual health test to
-  have returned `false`. To classify the projected step as `¬ healthy s`, the
-  remaining bridge must relate that generated post-accrual guard back to the
-  original projected pre-state on the local oracle-price/collateral-fit domain.
+  have returned `false`. `liquidate_preStateUnhealthy_of_accrueInterest_identity`
+  relates that generated post-accrual guard back to the original projected
+  pre-state under the no-accrual assumption.
 -/
 
 /-- `liquidate`: the generated `require(!_isHealthy)` guard, read off a
@@ -307,31 +307,45 @@ theorem guardUnhealthy_liquidate (P : Position)
   liquidate_guardUnhealthy_afterAccrue_price P hid hprice
 
 /-- Post-accrual/pre-state bridge from a successful `liquidate` run back to the
-    original projected pre-state. This is intentionally no longer called
-    `GuardUnhealthy`: the generated guard itself fires after `_accrueInterest`,
-    and that structural fact is proved by `guardUnhealthy_liquidate`. -/
+    original projected pre-state. The generated guard itself fires after
+    `_accrueInterest`, while this proposition records the no-accrual consequence
+    needed by the model-level classifier. -/
 def LiquidatePreStateUnhealthy (P : Position) : Prop :=
   ∀ seized repaid data out cs cs',
     (liquidate P.mp P.account seized repaid data).run cs
         = Verity.ContractResult.success out cs' →
+      ∃ csHealth,
       (_isHealthyWithPrice P.mp P.id P.account P.price).run cs
-        = Verity.ContractResult.success false cs
+        = Verity.ContractResult.success false csHealth
 
-/-- `liquidate` refines `¬ healthy s` from its guard plus the checked local
-    oracle-price/collateral-fit bridge: the guard makes the contract health test
-    `false` on the pre-state, and `healthFaithful_of_noOverflow` carries that to
-    the model's `healthy` predicate on the projection. -/
-theorem refines_liquidate (P : Position) (hpre : LiquidatePreStateUnhealthy P)
+/-- The post-accrual/pre-state bridge follows from the generated body and
+    no-accrual: `_accrueInterest` leaves the local state unchanged, so the
+    generated unhealthy guard can be replayed on the original pre-state. -/
+theorem liquidatePreStateUnhealthy_of_accrueInterestIdentity (P : Position)
+    (hid : MarketIdAligned P) (hprice : OraclePriceAligned P)
+    (hnoAccrual : AccrueInterestIdentityFor P) :
+    LiquidatePreStateUnhealthy P :=
+  liquidate_preStateUnhealthy_of_accrueInterest_identity P hid hprice hnoAccrual
+
+/-- `liquidate` refines `¬ healthy s` from its generated guard plus no-accrual:
+    the guard makes the contract health test `false` on the pre-state, and
+    `healthFaithful_of_noOverflow` carries that to the model's `healthy`
+    predicate on the projection. -/
+theorem refines_liquidate (P : Position)
+    (hid : MarketIdAligned P) (hprice : OraclePriceAligned P)
+    (hnoAccrual : AccrueInterestIdentityFor P)
     (horacleFits : LocalNoOverflowFor P) :
     Refines .liquidate (liquidateStep P) := by
   intro _ s s' h
   obtain ⟨seized, repaid, data, out, cs, cs', hs, _, hrun⟩ := h
-  have hbool := hpre seized repaid data out cs cs' hrun
+  obtain ⟨csHealth, hbool⟩ :=
+    liquidatePreStateUnhealthy_of_accrueInterestIdentity P hid hprice hnoAccrual
+      seized repaid data out cs cs' hrun
   have hfaith :=
     Morpho.Proofs.HealthFaithful.healthFaithful_of_noOverflow
       P.mp P.id P.account P.price cs
         (noOverflow_of_localNoOverflow P cs (horacleFits cs))
-  have hiff := hfaith false cs hbool
+  have hiff := hfaith false csHealth hbool
   simp only [classify, hs]
   exact fun hh => Bool.false_ne_true (hiff.mpr hh)
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ layer.
   (`guardedDiscipline_borrowCommitAndCheck`,
   `guardedDiscipline_borrowAssetsMode`, and
   `guardedDiscipline_borrowSharesMode`). `liquidate` now proves the generated
-  post-accrual `require(!_isHealthy)` extraction as `guardUnhealthy_liquidate`;
-  the remaining post-accrual/pre-state bridge is the explicitly named condition
-  `LiquidatePreStateUnhealthy`.
+  post-accrual `require(!_isHealthy)` extraction as `guardUnhealthy_liquidate`
+  and proves the post-accrual/pre-state bridge from the contract-side
+  no-accrual discipline (`AccrueInterestIdentityFor`).
   The remaining step-to-EVM-bytecode link is empirical, not yet a Lean extraction
   layer.
 - **Arithmetic.** Health arithmetic is modeled over `Nat`. It agrees with the

--- a/docs/REFINEMENT_DISCHARGE_AGENT_PLAN.md
+++ b/docs/REFINEMENT_DISCHARGE_AGENT_PLAN.md
@@ -20,11 +20,12 @@ Current state to re-check before editing:
   `guardedDiscipline_borrowAssetsMode`, and
   `guardedDiscipline_borrowSharesMode`; `Morpho/Proofs/Refinement.lean` now uses
   `guardedDiscipline_borrow` instead of a `GuardedDiscipline` assumption.
-- `liquidate` has the easy arithmetic-faithfulness side integrated through
-  `healthFaithful_of_noOverflow`, but still carries the harder generated
-  `GuardUnhealthy` extraction boundary.
-- Remaining hard areas are liquidation guard alignment, no-accrual alignment for
-  liquidation, and any further no-overflow propagation.
+- `liquidate` now proves the generated unhealthy guard extraction and the
+  post-accrual/pre-state bridge under the explicit contract-side no-accrual
+  discipline `AccrueInterestIdentityFor`.
+- Remaining hard areas are further no-overflow propagation and any future
+  replacement of the empirical step-to-EVM-bytecode link with a Lean extraction
+  layer.
 
 Always start with:
 
@@ -229,8 +230,8 @@ Lean:
 - `lake build` passes.
 - No new `axiom` or `constant` is introduced except the explicitly named slot/keccak injectivity boundary if it is truly required.
 - `Refinement.lean` no longer assumes `MonotoneDiscipline` or
-  `GuardedDiscipline` for the target entrypoints; `liquidate` may still carry
-  the explicitly deferred `GuardUnhealthy` extraction boundary.
+  `GuardedDiscipline` for the target entrypoints; `liquidate` no longer carries
+  the deferred `GuardUnhealthy` extraction boundary.
 - `HealthFaithful` is not used as an opaque assumption where `healthFaithful_of_noOverflow` can be used instead.
 
 Scripts:

--- a/docs/REFINEMENT_DISCHARGE_AGENT_PLAN.md
+++ b/docs/REFINEMENT_DISCHARGE_AGENT_PLAN.md
@@ -231,7 +231,8 @@ Lean:
 - No new `axiom` or `constant` is introduced except the explicitly named slot/keccak injectivity boundary if it is truly required.
 - `Refinement.lean` no longer assumes `MonotoneDiscipline` or
   `GuardedDiscipline` for the target entrypoints; `liquidate` no longer carries
-  the deferred `GuardUnhealthy` extraction boundary.
+  the generated unhealthy-guard extraction boundary or the post-accrual/pre-state
+  bridge as an external assumption.
 - `HealthFaithful` is not used as an opaque assumption where `healthFaithful_of_noOverflow` can be used instead.
 
 Scripts:

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -90,8 +90,8 @@ opaque assumptions:
   multiplication bounds explicit: the watched collateral times oracle price, and
   that quoted collateral times LLTV, must fit in `uint256`. The borrow-side
   share/asset conversion uses the full-precision `mulDiv512Up` helper, and its
-  quotient-fit proof is derived from the packed `uint128` storage reads before reconstructing the
-  `NoOverflowFor` predicate at the `healthFaithful_of_noOverflow` call site.
+  quotient-fit proof is derived from the packed `uint128` storage reads at the
+  `healthFaithful_of_noOverflow` call site.
 
 ## Current Gates
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -82,9 +82,10 @@ opaque assumptions:
 - `liquidate` no longer carries the structural generated-guard boundary:
   `guardUnhealthy_liquidate` proves that a successful generated body reached
   `require(!_isHealthy)` after `_accrueInterest` and that the health check
-  returned `false`. The remaining refinement bridge is the post-accrual/pre-state
-  `LiquidatePreStateUnhealthy`, which relates that post-accrual guard fact back
-  to the original projected pre-state.
+  returned `false`. The post-accrual/pre-state bridge is also proved in Lean:
+  `liquidate_preStateUnhealthy_of_accrueInterest_identity` uses the explicit
+  contract-side no-accrual discipline `AccrueInterestIdentityFor` to replay the
+  generated guard on the original projected pre-state.
 - Health arithmetic now exposes `LocalNoOverflowFor` with only the oracle-price
   multiplication bounds explicit: the watched collateral times oracle price, and
   that quoted collateral times LLTV, must fit in `uint256`. The borrow-side


### PR DESCRIPTION
## Summary
- prove the liquidate post-accrual/pre-state unhealthy bridge from the generated body under `AccrueInterestIdentityFor`
- wire `refines_liquidate` to use the proved bridge instead of taking `LiquidatePreStateUnhealthy` as an assumed boundary
- update README/trust-boundary docs to reflect that the remaining liquidation bridge is discharged in Lean under no-accrual

## Verification
- `lake build`
- `python3 scripts/check_morpho_artifact_boundary.py`
- `python3 -m pytest scripts -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal verification of liquidation refinement and introduces an explicit no-accrual assumption; incorrect proofs would weaken trust in the refinement layer but do not affect runtime contract code.
> 
> **Overview**
> Closes the **liquidate** refinement gap in Lean: a successful generated `liquidate` run can be shown to fail `_isHealthyWithPrice` on the **original** pre-state, not only after `_accrueInterest`.
> 
> **Disciplines** adds `AccrueInterestIdentityFor` (successful `_accrueInterest` is state-preserving) and proves `liquidate_preStateUnhealthy_of_accrueInterest_identity` by unfolding the generated body and replaying the post-accrual unhealthy guard when accrual is identity. **Refinement** wires `refines_liquidate` to that theorem via `liquidatePreStateUnhealthy_of_accrueInterestIdentity`, so `LiquidatePreStateUnhealthy` is no longer an external assumption; callers supply `AccrueInterestIdentityFor` instead. `LiquidatePreStateUnhealthy` now quantifies over an intermediate health-check state `csHealth` for alignment with `healthFaithful_of_noOverflow`.
> 
> Packed-word proof support moves to **`Morpho/Proofs/PackedWordLemmas.lean`** (imports switch from `Contracts.PackedWordLemmas`). README, trust boundaries, and the refinement agent plan are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4dc4d3c535f4b2285a3e98f9dcf8db88ed3cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->