### PR TITLE
Switch Midnight transfers to legacyStringSafeTransfer modules

### DIFF
--- a/artifacts/midnight-focused/MidnightRCF.artifact-manifest.env
+++ b/artifacts/midnight-focused/MidnightRCF.artifact-manifest.env
@@ -1,4 +1,4 @@
-input_digest=7338e45c4e021608f7c22ef669e9d1ec887f989aefe4af8d01a332c0dd0b1a24
+input_digest=373934ebabe09d303f0dcf2ea7278c865b09d8bd5b5e9c4ae3e13a2644908950
 artifact_scope=focused-midnight-rcf
 contract_name=MidnightRCF
 complete_imidnight_artifact=0

--- a/artifacts/midnight/Midnight.artifact-manifest.env
+++ b/artifacts/midnight/Midnight.artifact-manifest.env
@@ -1,4 +1,4 @@
-input_digest=60576dc503c70b884fa5ed36cecf2264c0c54fa884a51c1de436c275e5c24b74
+input_digest=4a7e81c7c1c91f9060b6d117014f173baace9622a2be554c86b31614e001bb39
 artifact_scope=midnight-full-imidnight
 contract_name=Midnight
 complete_imidnight_artifact=1

--- a/morpho-midnight-verity/Midnight/Contract.lean
+++ b/morpho-midnight-verity/Midnight/Contract.lean
@@ -2,6 +2,7 @@ import Contracts.Common
 import Compiler.Modules.Callbacks
 import Compiler.Modules.Calls
 import Compiler.Modules.Create2SSTORE2
+import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
 import Verity.Core
 import Verity.Macro
@@ -1747,10 +1748,6 @@ def marketReturnFromCodeModule : Compiler.ECM.ExternalCallModule where
 def arrayLength {α : Type} (values : Array α) : Uint256 := Contracts.arrayLength values
 def arrayElement {α : Type} [Inhabited α] (values : Array α) (index : Uint256) : α :=
   Contracts.arrayElement values index
-def safeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
-  Contracts.safeTransfer token toAddr amount
-def safeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
-  Contracts.safeTransferFrom token fromAddr toAddr amount
 def bitAnd (a b : Uint256) : Uint256 := Verity.Core.Uint256.and a b
 def bitOr (a b : Uint256) : Uint256 := Verity.Core.Uint256.or a b
 def bitNot (a : Uint256) : Uint256 := Verity.Core.Uint256.not a
@@ -2985,7 +2982,7 @@ verity_contract Midnight where
     let claimable ← getMapping claimableSettlementFeeSlot token
     requireError (amount <= claimable) ConsumedAssets()
     setMapping claimableSettlementFeeSlot token (sub claimable amount)
-    safeTransfer token receiver amount
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord token, addressToWord receiver, amount]
 
   function allow_post_interaction_writes claimContinuousFee
       (market : Market, amount : Uint256, receiver : Address)
@@ -3004,7 +3001,7 @@ verity_contract Midnight where
     let currentWithdrawable ← structMember "marketStateSlot" id "withdrawable"
     setStructMember "marketStateSlot" id "withdrawable" (sub currentWithdrawable amount)
     emit "ClaimContinuousFee" [sender, id, amount, receiver]
-    safeTransfer market.loanToken receiver amount
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord market.loanToken, addressToWord receiver, amount]
 
   function setMarketTickSpacing (id : Bytes32, newTickSpacing : Uint256)
       : Unit := do
@@ -3555,11 +3552,11 @@ verity_contract Midnight where
     let feeAssets := sub buyerAssets sellerAssets
     if feeAssets > ZERO then
       let self ← contractAddress
-      safeTransferFrom loanToken payer self feeAssets
+      ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord loanToken, addressToWord payer, addressToWord self, feeAssets]
     else
       pure ()
     if sellerAssets > ZERO then
-      safeTransferFrom loanToken payer receiver sellerAssets
+      ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord loanToken, addressToWord payer, addressToWord receiver, sellerAssets]
     else
       pure ()
     let mut sellerCallback := offer.callback
@@ -3700,7 +3697,7 @@ verity_contract Midnight where
     let total ← structMember "marketStateSlot" id "totalUnits"
     setStructMember "marketStateSlot" id "totalUnits" (sub total units)
     emit "Withdraw" [sender, id, units, onBehalf, receiver, pendingFeeDecrease]
-    safeTransfer market.loanToken receiver units
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord market.loanToken, addressToWord receiver, units]
 
   function allow_post_interaction_writes repay
       (market : Market, units : Uint256, onBehalf : Address,
@@ -3721,7 +3718,7 @@ verity_contract Midnight where
     else
       pure ()
     let self ← contractAddress
-    safeTransferFrom market.loanToken payer self units
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord market.loanToken, addressToWord payer, addressToWord self, units]
 
   function collateralTokenAt
       (collateralParams : Array CollateralParams, index : Uint256) : Address := do
@@ -5142,7 +5139,7 @@ verity_contract Midnight where
         postMaturityMode, receiver, payer, badDebt,
         add latestLossFactorLoaded ZERO,
         add latestContinuousFeeCreditLoaded ZERO]
-    safeTransfer collateralToken receiver outSeizedAssets
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord collateralToken, addressToWord receiver, outSeizedAssets]
     if callback != 0 then
       ecmDo liquidateCallbackModule
         [addressToWord callback, addressToWord sender, id, collateralIndex,
@@ -5151,7 +5148,7 @@ verity_contract Midnight where
     else
       pure ()
     let self ← contractAddress
-    safeTransferFrom market.loanToken payer self outRepaidUnits
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord market.loanToken, addressToWord payer, addressToWord self, outRepaidUnits]
     return (outSeizedAssets, outRepaidUnits)
 
   function isHealthy (market : Market, id : Bytes32, borrower : Address) : Bool := do
@@ -5204,7 +5201,7 @@ verity_contract Midnight where
       pure ()
     let collateralToken ← collateralTokenAt market.collateralParams collateralIndex
     let self ← contractAddress
-    safeTransferFrom collateralToken sender self assets
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord collateralToken, addressToWord sender, addressToWord self, assets]
     setCollateralAmount id onBehalf collateralIndex newCollateral
 
   function allow_post_interaction_writes withdrawCollateral
@@ -5233,7 +5230,7 @@ verity_contract Midnight where
     else
       pure ()
     let collateralToken ← collateralTokenAt market.collateralParams collateralIndex
-    safeTransfer collateralToken receiver assets
+    ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord collateralToken, addressToWord receiver, assets]
     setCollateralAmount id onBehalf collateralIndex newCollateral
 
   function allow_post_interaction_writes flashLoan
@@ -5243,12 +5240,12 @@ verity_contract Midnight where
     let assetCount := arrayLength assets
     requireError (tokenCount == assetCount) InconsistentInput()
     forEach "i" tokenCount (do
-      safeTransfer (arrayElement tokens i) callback (arrayElement assets i))
+      ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferModule) [addressToWord (arrayElement tokens i), addressToWord callback, arrayElement assets i])
     let sender ← msgSender
     ecmDo flashLoanCallbackModule [addressToWord callback, addressToWord sender]
     forEach "i" tokenCount (do
       let self ← contractAddress
-      safeTransferFrom (arrayElement tokens i) callback self (arrayElement assets i))
+      ecmDo (Compiler.Modules.ERC20.legacyStringSafeTransferFromModule) [addressToWord (arrayElement tokens i), addressToWord callback, addressToWord self, arrayElement assets i])
 
   function collateral (id : Bytes32, user : Address, index : Uint256) : Uint256 := do
     let value ← collateralAmount id user index

--- a/morpho-midnight-verity/Midnight/Proofs/TRUST_BOUNDARIES.md
+++ b/morpho-midnight-verity/Midnight/Proofs/TRUST_BOUNDARIES.md
@@ -10,6 +10,13 @@ protocol-specific ECMs where the current Verity source surface cannot yet expres
 the Solidity construct as typed code without hiding byte-level behavior. These
 are trust-report assumptions, not Lean proof-system axioms.
 
+**Token transfers** in the full artifact use Verity's
+`legacyStringSafeTransfer` / `legacyStringSafeTransferFrom` modules, which emit
+the exact Morpho `SafeTransferLib` Yul (code-length guard + string reverts
+`"no code"`, `"transfer reverted"`, `"transfer returned false"`,
+`"transferFrom reverted"`, `"transferFrom returned false"`, and the
+Solmate-style optional-bool check `returndatasize > 31 && mload == 1`).
+
 | ECM axiom(s) | Solidity construct represented | Why it remains an ECM |
 |--------------|--------------------------------|------------------------|
 | `midnight_multicall_bytes_array_abi`, `self_delegatecall_storage_context` | `multicall(bytes[] calldata)` self-`delegatecall` loop with revert-data bubbling. | Verity can emit the low-level loop, but `bytes[] calldata` iteration, delegatecall storage context, and returndata bubbling are still low-level mechanics rather than typed source. |


### PR DESCRIPTION
## Summary

Replace `Contracts.safeTransfer`/`safeTransferFrom` with Verity's
`legacyStringSafeTransfer`/`legacyStringSafeTransferFrom` modules via
`ecmDo`, matching the exact Morpho `SafeTransferLib` Yul:

- `extcodesize > 0` guard → revert `"no code"`
- Call failure → revert `"transfer reverted"` / `"transferFrom reverted"`
- Optional-bool check → revert `"transfer returned false"` / `"transferFrom returned false"`
- Solmate-style `returndatasize > 31 && mload == 1`

This brings Midnight's transfer handling to parity with Morpho Blue,
which already uses these modules (adopted in #376).

## Changes

- Replace 12 transfer call sites (6 `safeTransfer`, 6 `safeTransferFrom`) with explicit `ecmDo` calls using `Compiler.Modules.ERC20.legacyStringSafeTransferModule` / `legacyStringSafeTransferFromModule`
- Remove dead `safeTransfer`/`safeTransferFrom` wrapper functions (the `verity_contract` macro was already intercepting these calls, making the wrappers unreachable from contract blocks)
- Add `import Compiler.Modules.ERC20`
- Update `Midnight/Proofs/TRUST_BOUNDARIES.md` to document the transfer module usage
- Update focused + complete Midnight artifact manifests

## Verification

- `lake build Midnight` passes
- `lake build Morpho` passes (no regressions)
- 145/145 Morpho Blue parity tests pass (`MORPHO_IMPL=verity forge test`)
- Midnight parity tests require Linux CI runner (macOS lacks `setsid`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all loan/collateral/fee/flash-loan transfers are compiled and executed; behavior is intended to match Morpho Blue but touches many critical fund-move paths.
> 
> **Overview**
> **Midnight** token moves no longer go through `Contracts.safeTransfer` / `safeTransferFrom` wrappers; every transfer site now calls **`ecmDo`** on **`legacyStringSafeTransferModule`** / **`legacyStringSafeTransferFromModule`**, aligning emitted Yul with Morpho **`SafeTransferLib`** (code-length guard, string reverts, optional-bool handling).
> 
> The unused wrapper defs are removed and **`Compiler.Modules.ERC20`** is imported explicitly. **`TRUST_BOUNDARIES.md`** records that full-artifact transfers use these ECMs, and focused/full **Midnight artifact manifest** `input_digest` values are bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a86e9885beca3d13fc679c7f58df571dc75364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->